### PR TITLE
Add PR correlation to push events

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -60,12 +60,20 @@ impl Session {
     pub fn get_pull_requests(&self, owner: &str, repo: &str, state: Option<&str>,
                              head: Option<&str>)
                              -> Result<Vec<PullRequest>, String> {
-        self.client.get(format!("repos/{}/{}/pulls?state={}&head={}",
+        let prs: Vec<PullRequest> = try!(self.client.get(&format!("repos/{}/{}/pulls?state={}&head={}",
                                 owner,
                                 repo,
                                 state.unwrap_or(""),
-                                head.unwrap_or(""))
-            .as_str())
+                                head.unwrap_or(""))));
+
+        let prs: Vec<PullRequest> = prs.into_iter().filter(|p| {
+            if let Some(head) = head {
+                p.head.ref_name == head || p.head.sha == head
+            } else {
+                true
+            }
+        }).collect();
+        Ok(prs)
     }
 
     pub fn create_pull_request(&self, owner: &str, repo: &str, title: &str, body: &str,

--- a/src/github/models.rs
+++ b/src/github/models.rs
@@ -12,21 +12,80 @@ pub struct HookBody {
     pub pull_request: Option<PullRequest>,
     pub review: Option<Review>,
     pub label: Option<Label>,
+
+    // push event related stuff
+    #[serde(rename = "ref")]
+    pub ref_name: Option<String>,
+    pub after: Option<String>,
+    pub before: Option<String>,
+    pub compare: Option<String>,
+    pub forced: Option<bool>,
+    pub deleted: Option<bool>,
+    pub created: Option<bool>,
+    pub commits: Option<Vec<Commit>>,
 }
+
+impl HookBody {
+    pub fn ref_name(&self) -> &str {
+        match self.ref_name {
+            Some(ref v) => v,
+            None => "",
+        }
+    }
+
+    pub fn after(&self) -> &str {
+        match self.after {
+            Some(ref v) => v,
+            None => "",
+        }
+    }
+
+    pub fn before(&self) -> &str {
+        match self.before {
+            Some(ref v) => v,
+            None => "",
+        }
+    }
+
+    pub fn forced(&self) -> bool {
+        self.forced.unwrap_or(false)
+    }
+
+    pub fn created(&self) -> bool {
+        self.deleted.unwrap_or(false)
+    }
+
+    pub fn deleted(&self) -> bool {
+        self.deleted.unwrap_or(false)
+    }
+}
+
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct User {
     pub login: Option<String>,
+    pub name: Option<String>,
 }
 
 impl User {
     pub fn new(login: &str) -> User {
-        User { login: Some(login.to_string()) }
+        User {
+            login: Some(login.to_string()),
+            name: Some(login.to_string()),
+        }
     }
 
     pub fn login(&self) -> &str {
         if let Some(ref login) = self.login {
             login
+        } else {
+            ""
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        if let Some(ref name) = self.name {
+            name
         } else {
             ""
         }
@@ -83,6 +142,8 @@ pub struct BranchRef {
     #[serde(rename = "ref")]
     pub ref_name: String,
     pub sha: String,
+    pub user: User,
+    pub repo: Repo,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -152,6 +213,14 @@ impl Comment {
             None => "",
         }
     }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Commit {
+    pub id: String,
+    pub tree_id: String,
+    pub message: String,
+    pub url: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -58,7 +58,11 @@ impl RepoConfig {
             Ok(u) => {
                 u.host_str()
                     .and_then(|h| self.repos.get(h))
-                    .and_then(|m| m.get(&repo.full_name).or(m.get(repo.owner.login())))
+                    .and_then(|m| {
+                        m.get(&repo.full_name)
+                            .or(m.get(repo.owner.login()))
+                            .or(m.get(repo.owner.name()))
+                    })
             }
             Err(_) => None,
         }


### PR DESCRIPTION
- Get a slack notification when PRs are updated
- Begin to add support for doing things like re-approval on force push
  as well as adding comments on force-push to get better history
  on PRs force pushes.