### PR TITLE
Include author participants in slack messages

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -25,6 +25,9 @@ pub trait Session : Send + Sync {
     fn get_pull_request_labels(&self, owner: &str, repo: &str, number: u32)
                                -> Result<Vec<Label>, String>;
 
+    fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32)
+                                    -> Result<Vec<Commit>, String>;
+
     fn assign_pull_request(&self, owner: &str, repo: &str, number: u32, assignees: Vec<String>)
                            -> Result<AssignResponse, String>;
 
@@ -126,8 +129,12 @@ impl Session for GithubSession {
 
     fn get_pull_request_labels(&self, owner: &str, repo: &str, number: u32)
                                    -> Result<Vec<Label>, String> {
-
         self.client.get(&format!("repos/{}/{}/issues/{}/labels", owner, repo, number))
+    }
+
+    fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32)
+                                    -> Result<Vec<Commit>, String> {
+        self.client.get(&format!("repos/{}/{}/pulls/{}/commits", owner, repo, number))
     }
 
     fn assign_pull_request(&self, owner: &str, repo: &str, number: u32,

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -10,7 +10,7 @@ use util;
 pub trait Messenger {
     fn send_to_all(&self, msg: &str, attachments: &Vec<SlackAttachment>,
                    item_owner: &github::User, sender: &github::User, repo: &github::Repo,
-                   assignees: &Vec<github::User>);
+                   participants: &Vec<github::User>);
 
     fn send_to_owner(&self, msg: &str, attachments: &Vec<SlackAttachment>,
                      item_owner: &github::User, repo: &github::Repo);
@@ -37,12 +37,12 @@ const DND_MARKER: &'static str = "DO NOT DISTURB";
 impl Messenger for SlackMessenger {
     fn send_to_all(&self, msg: &str, attachments: &Vec<SlackAttachment>,
                    item_owner: &github::User, sender: &github::User, repo: &github::Repo,
-                   assignees: &Vec<github::User>) {
+                   participants: &Vec<github::User>) {
         self.send_to_channel(msg, attachments, repo);
 
         let mut slackbots: Vec<github::User> = vec![item_owner.clone()];
 
-        slackbots.extend(assignees.iter()
+        slackbots.extend(participants.iter()
             .filter(|a| a.login != item_owner.login)
             .map(|a| a.clone()));
 

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -84,7 +84,6 @@ impl RepoConfig {
                     .and_then(|m| {
                         m.get(&repo.full_name)
                             .or(m.get(repo.owner.login()))
-                            .or(m.get(repo.owner.name()))
                     })
             }
             Err(_) => None,


### PR DESCRIPTION
Scenario: UserA creates PR1 and it gets merged. Octobot merges PR1
into a release branch and creates PR2. Since Octobot was the creator
of PR2, UserA does not receive any slack notifications about PR2
even though UserA is the actual author.

Note: This does not include all commentors on the PR as per the
github UI's notion of "participants". I think it would probably be
too assuming to send slackbot notifications to people just for having
commented. If they have an interest in notifications, they can
assign themselves.