### PR TITLE
Change to make review/resolved status explicit

### DIFF
--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1005,7 +1005,7 @@ fn some_jira_commits() -> Vec<Commit> {
             html_url: "http://commit/ffeedd00110011".into(),
             author: Some(User::new("bob-author")),
             commit: CommitDetails {
-                message: "[SER-1] Add the feature\n\nThe body".into(),
+                message: "Fix [SER-1] Add the feature\n\nThe body".into(),
             }
         },
     ]
@@ -1017,7 +1017,7 @@ fn some_jira_push_commits() -> Vec<PushCommit> {
             id: "ffeedd00110011".into(),
             tree_id: "ffeedd00110011".into(),
             url: "http://commit/ffeedd00110011".into(),
-            message: "[SER-1] Add the feature\n\nThe body".into(),
+            message: "Fix [SER-1] Add the feature\n\nThe body".into(),
         },
     ]
 }
@@ -1070,7 +1070,7 @@ fn test_jira_push_master() {
     test.github.mock_get_pull_requests("some-user", "some-repo", Some("open".into()), Some("1111abcdef"), Ok(vec![]));
 
     if let Some(ref jira) = test.jira {
-        jira.mock_comment_issue("SER-1", "[ffeedd0|http://commit/ffeedd00110011]\n{quote}[SER-1] Add the feature\n\nThe body{quote}", Ok(()));
+        jira.mock_comment_issue("SER-1", "[ffeedd0|http://commit/ffeedd00110011]\n{quote}Fix [SER-1] Add the feature\n\nThe body{quote}", Ok(()));
 
         jira.mock_get_transitions("SER-1", Ok(vec![new_transition("003", "the-resolved")]));
         jira.mock_transition_issue("SER-1", &new_transition_req("003"), Ok(()));

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -82,7 +82,7 @@ fn new_transition_req(id: &str) -> TransitionRequest {
 fn test_submit_for_review() {
     let test = new_test();
     let pr = new_pr();
-    let commit = new_commit("[SER-1] I fixed it. And also [CLI-9999]", "aabbccddee");
+    let commit = new_commit("Fix [SER-1] I fixed it. And also fix [CLI-9999]", "aabbccddee");
 
     test.jira.mock_comment_issue("CLI-9999", "Review submitted for branch master: http://the-pr", Ok(()));
     test.jira.mock_comment_issue("SER-1", "Review submitted for branch master: http://the-pr", Ok(()));
@@ -104,10 +104,10 @@ fn test_submit_for_review() {
 fn test_resolve_issue_no_resolution() {
     let test = new_test();
     let pr = new_pr();
-    let commit1 = new_push_commit("[SER-1] I fixed it. And also [CLI-9999]\n\n\n\n", "aabbccddee");
+    let commit1 = new_push_commit("Fix [SER-1] I fixed it. And also fix [CLI-9999]\n\n\n\n", "aabbccddee");
     let commit2 = new_push_commit("Really fix [CLI-9999]\n\n\n\n", "ffbbccddee");
 
-    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}[SER-1] I fixed it. And also [CLI-9999]\n\n\n\n{quote}\
+    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it. And also fix [CLI-9999]\n\n\n\n{quote}\
                     \nMerged into branch master: http://the-pr";
     let comment2 = "[ffbbccd|http://the-commit/ffbbccddee]\n{quote}Really fix [CLI-9999]\n\n\n\n{quote}\
                     \nMerged into branch master: http://the-pr";
@@ -133,13 +133,13 @@ fn test_resolve_issue_no_resolution() {
 fn test_resolve_issue_with_resolution() {
     let test = new_test();
     let pr = new_pr();
-    let commit = new_push_commit("[SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]", "aabbccddee");
+    let commit = new_push_commit("Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]", "aabbccddee");
 
-    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}[SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
+    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
                    \nMerged into branch master: http://the-pr";
     test.jira.mock_comment_issue("SER-1", comment1, Ok(()));
 
-    let comment2 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}[SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
+    let comment2 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
                    \nReferenced by commit merged into branch master: http://the-pr";
     test.jira.mock_comment_issue("CLI-45", comment2, Ok(()));
 


### PR DESCRIPTION
Commit message must now contain "Fix"/"Fixes"/"Fixed"/etc.
in order for octobot to trigger jira transitions