### PR TITLE
Separate out git clone management

### DIFF
--- a/src/git_clone_manager.rs
+++ b/src/git_clone_manager.rs
@@ -1,0 +1,56 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use config::Config;
+use dir_pool::{DirPool, HeldDir};
+use git::Git;
+use github;
+
+// clones git repos with given github session into a managed directory pool
+pub struct GitCloneManager {
+    dir_pool: Arc<DirPool>,
+    git: Git,
+    github_session: Arc<github::api::Session>,
+}
+
+impl GitCloneManager {
+    pub fn new(github_session: Arc<github::api::Session>, config: Arc<Config>) -> GitCloneManager {
+        let clone_root_dir = config.clone_root_dir.to_string();
+
+        GitCloneManager {
+            dir_pool: Arc::new(DirPool::new(&clone_root_dir)),
+            git: Git::new(github_session.github_host(), github_session.github_token()),
+            github_session: github_session.clone(),
+        }
+    }
+
+    pub fn clone(&self, owner: &str, repo: &str) -> Result<HeldDir, String> {
+        let held_clone_dir = self.dir_pool.take_directory(self.github_session.github_host(), owner, repo);
+        try!(self.clone_repo(owner, repo, &held_clone_dir.dir()));
+
+        Ok(held_clone_dir)
+    }
+
+    fn clone_repo(&self, owner: &str, repo: &str, clone_dir: &PathBuf) -> Result<(), String> {
+        let url = format!("https://{}@{}/{}/{}",
+                          self.github_session.user().login(),
+                          self.github_session.github_host(),
+                          owner,
+                          repo);
+
+        if clone_dir.join(".git").exists() {
+            try!(self.git.run(&["fetch", "--prune"], clone_dir));
+        } else {
+            if let Err(e) = fs::create_dir_all(&clone_dir) {
+                return Err(format!("Error creating clone directory '{:?}': {}", clone_dir, e));
+            }
+            try!(self.git.run(&["clone", &url, "."], clone_dir));
+        }
+
+        // always fetch latest tags
+        try!(self.git.run(&["fetch", "--tags"], clone_dir));
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate serde_derive;
 pub mod config;
 pub mod dir_pool;
 pub mod git;
+pub mod git_clone_manager;
 pub mod github;
 pub mod jira;
 pub mod messenger;

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -16,6 +16,7 @@ use octobot::repos::RepoConfig;
 use octobot::users::UserConfig;
 use octobot::github::*;
 use octobot::github::api::Session;
+use octobot::git_clone_manager::GitCloneManager;
 use octobot::jira;
 use octobot::messenger::SlackMessenger;
 use octobot::slack::SlackAttachmentBuilder;
@@ -87,6 +88,7 @@ fn new_test() -> GithubHandlerTest {
     data.sender = User::new("joe-sender");
 
     let config = Arc::new(Config::new(UserConfig::new(), repos));
+    let git_clone_manager = Arc::new(GitCloneManager::new(github.clone(), config.clone()));
 
     GithubHandlerTest {
         github: github.clone(),
@@ -103,6 +105,7 @@ fn new_test() -> GithubHandlerTest {
                 slack: slack.clone(),
             }),
             github_session: github.clone(),
+            git_clone_manager: git_clone_manager.clone(),
             jira_session: None,
             pr_merge: tx.clone(),
         },


### PR DESCRIPTION
Moving this code out of the pr_merge module allows us to share it
with other background threads, e.g. for calculating git versions