### PR TITLE
Use branch name, not PRs for resolving JIRA issues

### DIFF
--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -488,7 +488,7 @@ impl GithubEventHandler {
                     if let Some(ref jira_config) = self.config.jira {
                         if let Some(ref jira_session) = self.jira_session {
                             if let Some(ref commits) = self.data.commits {
-                                jira::workflow::resolve_issue(&prs, commits, jira_session.deref(), jira_config);
+                                jira::workflow::resolve_issue(&branch_name, commits, jira_session.deref(), jira_config);
 
                                 if self.config.repos.version_script(&self.data.repository).is_some() {
                                     let msg = RepoVersionMessage::version(&self.data.repository, &branch_name, self.data.after(), commits);

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1079,7 +1079,7 @@ fn test_jira_push_master() {
     test.github.mock_get_pull_requests("some-user", "some-repo", Some("open".into()), Some("1111abcdef"), Ok(vec![]));
 
     if let Some(ref jira) = test.jira {
-        jira.mock_comment_issue("SER-1", "[ffeedd0|http://commit/ffeedd00110011]\n{quote}Fix [SER-1] Add the feature\n\nThe body{quote}", Ok(()));
+        jira.mock_comment_issue("SER-1", "Merged into branch master: [ffeedd0|http://commit/ffeedd00110011]\n{quote}Fix [SER-1] Add the feature\n\nThe body{quote}", Ok(()));
 
         jira.mock_get_transitions("SER-1", Ok(vec![new_transition("003", "the-resolved")]));
         jira.mock_transition_issue("SER-1", &new_transition_req("003"), Ok(()));
@@ -1158,7 +1158,7 @@ fn test_jira_push_triggers_version_script() {
     test.github.mock_get_pull_requests("some-user", "versioning-repo", Some("open".into()), Some("1111abcdef"), Ok(vec![]));
 
     if let Some(ref jira) = test.jira {
-        jira.mock_comment_issue("SER-1", "[ffeedd0|http://commit/ffeedd00110011]\n{quote}Fix [SER-1] Add the feature\n\nThe body{quote}", Ok(()));
+        jira.mock_comment_issue("SER-1", "Merged into branch master: [ffeedd0|http://commit/ffeedd00110011]\n{quote}Fix [SER-1] Add the feature\n\nThe body{quote}", Ok(()));
 
         jira.mock_get_transitions("SER-1", Ok(vec![new_transition("003", "the-resolved")]));
         jira.mock_transition_issue("SER-1", &new_transition_req("003"), Ok(()));

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -103,14 +103,13 @@ fn test_submit_for_review() {
 #[test]
 fn test_resolve_issue_no_resolution() {
     let test = new_test();
-    let pr = new_pr();
     let commit1 = new_push_commit("Fix [SER-1] I fixed it. And also fix [CLI-9999]\n\n\n\n", "aabbccddee");
     let commit2 = new_push_commit("Really fix [CLI-9999]\n\n\n\n", "ffbbccddee");
 
-    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it. And also fix [CLI-9999]\n\n\n\n{quote}\
-                    \nMerged into branch master: http://the-pr";
-    let comment2 = "[ffbbccd|http://the-commit/ffbbccddee]\n{quote}Really fix [CLI-9999]\n\n\n\n{quote}\
-                    \nMerged into branch master: http://the-pr";
+    let comment1 = "Merged into branch master: [aabbccd|http://the-commit/aabbccddee]\n\
+                   {quote}Fix [SER-1] I fixed it. And also fix [CLI-9999]\n\n\n\n{quote}";
+    let comment2 = "Merged into branch master: [ffbbccd|http://the-commit/ffbbccddee]\n\
+                    {quote}Really fix [CLI-9999]\n\n\n\n{quote}";
 
     test.jira.mock_comment_issue("CLI-9999", comment1, Ok(()));
     test.jira.mock_comment_issue("SER-1", comment1, Ok(()));
@@ -126,21 +125,20 @@ fn test_resolve_issue_no_resolution() {
     test.jira.mock_get_transitions("CLI-9999", Ok(vec![new_transition("004", "resolved2")]));
     test.jira.mock_transition_issue("CLI-9999", &new_transition_req("004"), Ok(()));
 
-    jira::workflow::resolve_issue(&vec![pr], &vec![commit1, commit2], &test.jira, &test.config);
+    jira::workflow::resolve_issue("master", &vec![commit1, commit2], &test.jira, &test.config);
 }
 
 #[test]
 fn test_resolve_issue_with_resolution() {
     let test = new_test();
-    let pr = new_pr();
     let commit = new_push_commit("Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]", "aabbccddee");
 
-    let comment1 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
-                   \nMerged into branch master: http://the-pr";
+    let comment1 = "Merged into branch release/99: [aabbccd|http://the-commit/aabbccddee]\n\
+                   {quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}";
     test.jira.mock_comment_issue("SER-1", comment1, Ok(()));
 
-    let comment2 = "[aabbccd|http://the-commit/aabbccddee]\n{quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}\
-                   \nReferenced by commit merged into branch master: http://the-pr";
+    let comment2 = "Referenced by commit merged into branch release/99: [aabbccd|http://the-commit/aabbccddee]\n\
+                   {quote}Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45]{quote}";
     test.jira.mock_comment_issue("CLI-45", comment2, Ok(()));
 
 
@@ -171,6 +169,6 @@ fn test_resolve_issue_with_resolution() {
     test.jira.mock_get_transitions("SER-1", Ok(vec![trans]));
     test.jira.mock_transition_issue("SER-1", &req, Ok(()));
 
-    jira::workflow::resolve_issue(&vec![pr], &vec![commit], &test.jira, &test.config);
+    jira::workflow::resolve_issue("release/99", &vec![commit], &test.jira, &test.config);
 }
 


### PR DESCRIPTION
When "squash and merge" is used (or when there is no PR involved at all),
it is hard/impossible to tie this commit back to the PR to get its
branch name, which is silly anyway since we already have the branch
name the commit was pushed to!