### PR TITLE
Reshuffle some code into git.rs

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,27 +1,29 @@
 use std::env;
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct Git {
     pub host: String,
     pub token: String,
+    repo_dir: PathBuf,
 }
 
 impl Git {
-    pub fn new(host: &str, token: &str) -> Git {
+    pub fn new(host: &str, token: &str, repo_dir: &Path) -> Git {
         Git {
             host: host.to_string(),
             token: token.to_string(),
+            repo_dir: repo_dir.to_owned(),
         }
     }
 
-    pub fn run(&self, args: &[&str], cwd: &Path) -> Result<String, String> {
-        self.do_run(args, cwd, None)
+    pub fn run(&self, args: &[&str]) -> Result<String, String> {
+        self.do_run(args, None)
     }
 
-    pub fn run_with_stdin(&self, args: &[&str], cwd: &Path, stdin: &str) -> Result<String, String> {
-        self.do_run(args, cwd, Some(stdin))
+    pub fn run_with_stdin(&self, args: &[&str], stdin: &str) -> Result<String, String> {
+        self.do_run(args, Some(stdin))
     }
 
     fn ask_pass_path(&self) -> String {
@@ -32,29 +34,70 @@ impl Git {
             }
             _ => ask_pass.to_string(),
         }
-
     }
 
-    pub fn has_branch(&self, branch: &str, cwd: &Path) -> Result<bool, String> {
-        let output = try!(self.run(&["branch"], cwd));
+    pub fn has_branch(&self, branch: &str) -> Result<bool, String> {
+        let output = try!(self.run(&["branch"]));
         // skip first two characters for the bullet point
         Ok(output.lines().any(|b| b.len() > 2 && branch == &b[2..]))
     }
 
-    pub fn current_branch(&self, cwd: &Path) -> Result<String, String> {
-        self.run(&["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    pub fn current_branch(&self) -> Result<String, String> {
+        self.run(&["rev-parse", "--abbrev-ref", "HEAD"])
     }
 
-    pub fn clean(&self, cwd: &Path) -> Result<(), String> {
-        try!(self.run(&["reset", "--hard"], cwd));
-        try!(self.run(&["clean", "-fdx"], cwd));
+    pub fn clean(&self) -> Result<(), String> {
+        try!(self.run(&["reset", "--hard"]));
+        try!(self.run(&["clean", "-fdx"]));
         Ok(())
     }
 
-    fn do_run(&self, args: &[&str], cwd: &Path, stdin: Option<&str>) -> Result<String, String> {
+    // checking a branch named |new_branch_name| and ensure it is up to date with |source_branch|
+    // |source_branch| can be a commit hash or an origin/branch-name.
+    pub fn checkout_branch(&self, new_branch_name: &str, source_branch: &str) ->  Result<(), String> {
+        let current_branch = try!(self.current_branch());
+        if current_branch == new_branch_name {
+            try!(self.run(&["reset", "--hard", &source_branch]));
+        } else {
+            // delete if it exists
+            let has_branch = try!(self.has_branch(new_branch_name));
+            if has_branch {
+                try!(self.run(&["branch", "-D", new_branch_name]));
+            }
+            // recreate branch
+            try!(self.run(&["checkout", "-b", new_branch_name, &source_branch]));
+        }
+
+        Ok(())
+    }
+
+    // returns (title, body)
+    pub fn get_commit_desc(&self, commit_hash: &str) -> Result<(String, String), String> {
+        let lines: Vec<String> = try!(self.run(&["log", "-1", "--pretty=%B", commit_hash]))
+            .split("\n")
+            .map(|l| l.trim().to_string())
+            .collect();
+
+        if lines.len() == 0 {
+            return Err(format!("Empty commit message found!"));
+        }
+
+        let title = lines[0].clone();
+
+        let mut body = String::new();
+        // skip the blank line
+        if lines.len() > 2 {
+            body = lines[2..].join("\n");
+            body += "\n";
+        }
+
+        Ok((title, body))
+    }
+
+    fn do_run(&self, args: &[&str], stdin: Option<&str>) -> Result<String, String> {
         debug!("Running git with args: {:?}", args);
         let cmd = Command::new("git")
-            .current_dir(cwd)
+            .current_dir(&self.repo_dir)
             .stdin(if stdin.is_some() {
                 Stdio::piped()
             } else {

--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -26,24 +26,10 @@ pub fn comment_repo_version(version_script: &Vec<String>,
     let held_clone_dir = try!(clone_mgr.clone(owner, repo));
     let clone_dir = held_clone_dir.dir();
 
-    let git = Git::new(github.github_host(), github.github_token());
-
-    // clean up state
-    try!(git.clean(clone_dir));
+    let git = Git::new(github.github_host(), github.github_token(), &clone_dir);
 
     // setup branch
-    let current_branch = try!(git.current_branch(clone_dir));
-    if current_branch == branch_name {
-        try!(git.run(&["reset", "--hard", commit_hash], clone_dir));
-    } else {
-        // delete if it exists
-        let has_branch = try!(git.has_branch(branch_name, clone_dir));
-        if has_branch {
-            try!(git.run(&["branch", "-D", branch_name], clone_dir));
-        }
-        // recreate branch
-        try!(git.run(&["checkout", "-b", branch_name, commit_hash], clone_dir));
-    }
+    try!(git.checkout_branch(branch_name, commit_hash));
 
     let version = try!(run_script(version_script, clone_dir));
 


### PR DESCRIPTION
Also, more meaningfully:
- Centralize code to checkout a branch from a source ref
- Centralize clean operation in git clone manager
- Stop passing the clone_dir around everywhere and attach it onto
  the git::Git struct.