### PR TITLE
Stop using --fork-point

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -56,7 +56,7 @@ impl Git {
     // This can find which commits belong to a PR.
     // Returns the ref found in the base branch that this git_ref came from.
     pub fn find_base_branch_commit(&self, leaf_ref: &str, base_branch: &str) -> Result<String, String> {
-        self.run(&["merge-base", "--fork-point", base_branch, leaf_ref])
+        self.run(&["merge-base", base_branch, leaf_ref])
     }
 
     pub fn clean(&self) -> Result<(), String> {


### PR DESCRIPTION
Looks like merge-base works fine w/o --fork-point and files sometimes
with --fork-point. Also looks like that option is doing some extra
things w/ the reflog that we probably don't want.