### PR TITLE
Add test for get_commit_desc and refactor

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -94,25 +94,13 @@ impl Git {
 
     // returns (title, body)
     pub fn get_commit_desc(&self, commit_hash: &str) -> Result<(String, String), String> {
-        let lines: Vec<String> = try!(self.run(&["log", "-1", "--pretty=%B", commit_hash]))
-            .split("\n")
-            .map(|l| l.trim().to_string())
-            .collect();
+        let message = try!(self.run(&["log", "-1", "--pretty=%B", commit_hash]));
 
-        if lines.len() == 0 {
-            return Err(format!("Empty commit message found!"));
-        }
+        let mut lines = message.lines();
+        let title: String = lines.next().unwrap_or("").into();
+        let body: Vec<&str> = lines.skip_while(|ref l| l.trim().len() == 0).collect();
 
-        let title = lines[0].clone();
-
-        let mut body = String::new();
-        // skip the blank line
-        if lines.len() > 2 {
-            body = lines[2..].join("\n");
-            body += "\n";
-        }
-
-        Ok((title, body))
+        Ok((title, body.join("\n")))
     }
 
     fn do_run(&self, args: &[&str], stdin: Option<&str>) -> Result<String, String> {

--- a/tests/git_test.rs
+++ b/tests/git_test.rs
@@ -110,3 +110,17 @@ fn test_does_branch_contain() {
     assert!(!test.git.does_branch_contain(&commit2, "eagle").unwrap(), "eagle should not contain commit2");
     assert!(!test.git.does_branch_contain(&commit2, "falcon").unwrap(), "falcon should not contain commit2");
 }
+
+#[test]
+fn test_get_commit_desc() {
+    let test = GitTest::new();
+
+    test.run_git(&["commit", "--amend", "-m", "I have just a subject"]);
+    assert_eq!(Ok(("I have just a subject".into(), String::new())), test.git.get_commit_desc("HEAD"));
+
+    test.run_git(&["commit", "--amend", "-m", "I have a subject\n\nAnd I have a body"]);
+    assert_eq!(Ok(("I have a subject".into(), "And I have a body".into())), test.git.get_commit_desc("HEAD"));
+
+    test.run_git(&["commit", "--amend", "-m", "I have a subject\nAnd I forgot to skip a line"]);
+    assert_eq!(Ok(("I have a subject".into(), "And I forgot to skip a line".into())), test.git.get_commit_desc("HEAD"));
+}


### PR DESCRIPTION
Also clean up to not unnecessarily add newlines or enforce a blank second line