### PR TITLE
Allow /etc/alternatives in version scripts

### DIFF
--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -60,7 +60,7 @@ fn run_script(version_script: &str, clone_dir: &Path) -> Result<String, String> 
         .arg("--overlay-tmpfs")
         .arg("--quiet")
         .arg("--private=.")
-        .arg("--private-etc=hostname")
+        .arg("--private-etc=hostname alternatives")
         .arg("--net=none")
         .arg("--private-tmp")
         .arg("--private-dev")


### PR DESCRIPTION
Some useful things in /usr/bin are symlinks into /etc/alternatives
(like `awk` in ubuntu)