### PR TITLE
Use full commit hash in 'cherry-picked from'.

### DIFF
--- a/src/pr_merge.rs
+++ b/src/pr_merge.rs
@@ -107,10 +107,7 @@ impl<'a> Merger<'a> {
         if body.len() != 0 {
             body += "\n\n";
         }
-        body += format!("(cherry-picked from {}, PR #{})",
-                        &commit_hash[0..7],
-                        pr_number)
-            .as_str();
+        body += format!("(cherry-picked from {}, PR #{})", commit_hash, pr_number).as_str();
 
         // change commit message
         try!(git.run_with_stdin(&["commit", "--amend", "-F", "-"], &format!("{}\n\n{}", title, body)));


### PR DESCRIPTION
If a repository gets large, then it's possible that
there will be collisions on the short hash. The
pull-request number should disambiguate it, but it'd
be cool if the hash also did not collide.

GitHub will shorten full hashes to the short form in
the pull-request UI, so I think it should still appear
the same.