### PR TITLE
Add explicit JIRA project list to repo config

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -199,9 +199,6 @@ app.controller('ReposController', function($rootScope, $scope, sessionHttp, noti
           if (info.force_push_notify == null)  {
             info.force_push_notify = true;
           }
-          if (info.jira_enabled == null)  {
-            info.jira_enabled = true;
-          }
           if (info.jira_versions_enabled == null)  {
             info.jira_versions_enabled = true;
           }
@@ -219,7 +216,6 @@ app.controller('ReposController', function($rootScope, $scope, sessionHttp, noti
   $scope.addRepo = function(host) {
     $scope.reposMap[host].push({
       force_push_notify: true,
-      jira_enabled: true,
       jira_versions_enabled: true,
     });
   }

--- a/src/assets/repos.html
+++ b/src/assets/repos.html
@@ -18,8 +18,9 @@
           <input type="text" class="form-control" ng-model="info.channel" placeholder="Slack channel" required>
         </td>
         <td>
-          <div>
-            <label><input type="checkbox" class="form-control" ng-model="info.jira_enabled"> JIRA enabled</label>
+          <div class="row">
+            <div class="col-md-5">JIRA project(s)</div>
+            <div class="col-md-7"><input type="text" class="form-control" ng-model="info.jira_projects" ng-list=", " style="width:100%"></div>
           </div>
           <div>
             <label><input type="checkbox" class="form-control" ng-model="info.jira_versions_enabled"> JIRA versions enabled</label>

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -92,9 +92,10 @@ fn new_test_with(jira: Option<JiraConfig>) -> GithubHandlerTest {
     let mut repos = RepoConfig::new();
     let mut data = HookBody::new();
 
-    repos.insert(github.github_host(),
-                 "some-user/some-repo",
-                 "the-reviews-channel");
+    let repo_info = repos::RepoInfo::new("some-user/some-repo", "the-reviews-channel")
+        .with_jira(vec!["SER".to_string(), "CLI".to_string()]);
+    repos.insert_info(github.github_host(), repo_info);
+
     data.repository = Repo::parse(&format!("http://{}/some-user/some-repo", github.github_host()))
         .unwrap();
     data.sender = User::new("joe-sender");
@@ -1104,7 +1105,7 @@ fn some_jira_commits() -> Vec<Commit> {
             html_url: "http://commit/ffeedd00110011".into(),
             author: Some(User::new("bob-author")),
             commit: CommitDetails {
-                message: "Fix [SER-1] Add the feature\n\nThe body".into(),
+                message: "Fix [SER-1] Add the feature\n\nThe body ([OTHER-123])".into(),
             }
         },
     ]
@@ -1116,7 +1117,7 @@ fn some_jira_push_commits() -> Vec<PushCommit> {
             id: "ffeedd00110011".into(),
             tree_id: "ffeedd00110011".into(),
             url: "http://commit/ffeedd00110011".into(),
-            message: "Fix [SER-1] Add the feature\n\nThe body".into(),
+            message: "Fix [SER-1] Add the feature\n\nThe body ([OTHER-123])".into(),
         },
     ]
 }


### PR DESCRIPTION
Now that we are going to be adding versions and not just comments, we want
to be a bit more sure that the jira project is the right one for that repo.

This also paves the way for allowing separate JIRA projects for different
release branches in the case of the monolothic repo scenario.