### PR TITLE
Add versions to "Pending Versions" text field instead

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,7 +62,9 @@ pub struct JiraConfig {
     // when marking as resolved, add this resolution (defaults to ["Fixed", "Done"])
     pub fixed_resolutions: Option<Vec<String>>,
     // the field name for where the version goes. (defaults to "fixVersions").
-    pub fix_version_field: Option<String>,
+    pub fix_versions_field: Option<String>,
+    // the field name for where the pending build versions go. expected to be a plain text field
+    pub pending_versions_field: Option<String>,
 }
 
 impl Config {
@@ -212,8 +214,8 @@ impl JiraConfig {
         }
     }
 
-    pub fn fix_version(&self) -> String {
-        if let Some(ref field) = self.fix_version_field {
+    pub fn fix_versions(&self) -> String {
+        if let Some(ref field) = self.fix_versions_field {
             field.clone()
         } else {
             "fixVersions".into()

--- a/src/jira/models.rs
+++ b/src/jira/models.rs
@@ -53,6 +53,12 @@ pub struct IDOrName {
     pub name: Option<String>,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct Field {
+    pub id: String,
+    pub name: String,
+}
+
 impl Transition {
     pub fn new_request(&self) -> TransitionRequest {
         TransitionRequest {

--- a/src/jira/workflow.rs
+++ b/src/jira/workflow.rs
@@ -158,20 +158,30 @@ pub fn resolve_issue(branch: &str,
     }
 }
 
+pub fn add_pending_version(maybe_version: Option<&str>, commits: &Vec<PushCommit>, projects: &Vec<String>, jira: &jira::api::Session) {
+    if let Some(version) = maybe_version {
+        for key in get_all_jira_keys(commits, projects) {
+            if let Err(e) = jira.add_pending_version(&key, version) {
+                error!("Error adding pending version {} to key{}: {}", version, key, e);
+                continue;
+            }
+        }
+    }
+}
+
 pub fn add_version(maybe_version: Option<&str>, commits: &Vec<PushCommit>, projects: &Vec<String>, jira: &jira::api::Session) {
     if let Some(version) = maybe_version {
         for key in get_all_jira_keys(commits, projects) {
             let proj = get_jira_project(&key);
             if let Err(e) = jira.add_version(proj, version) {
                 error!("Error adding version {} to project {}: {}", version, proj, e);
-                return;
+                continue;
             }
 
             if let Err(e) = jira.assign_fix_version(&key, version) {
                 error!("Error assigning version {} to key {}: {}", version, key, e);
-                return;
+                continue;
             }
-
         }
     }
 }

--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -51,7 +51,7 @@ pub fn comment_repo_version(version_script: &str,
     jira::workflow::resolve_issue(branch_name, maybe_version, commits, jira_projects, jira, jira_config);
 
     if jira_versions_enabled {
-        jira::workflow::add_version(maybe_version, commits, jira_projects, jira);
+        jira::workflow::add_pending_version(maybe_version, commits, jira_projects, jira);
     }
 
     Ok(())

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -141,7 +141,8 @@ fn new_test_with_jira() -> GithubHandlerTest {
         review_states: Some(vec!["the-review".into()]),
         resolved_states: Some(vec!["the-resolved".into()]),
         fixed_resolutions: Some(vec![":boom:".into()]),
-        fix_version_field: Some("the-versions".into()),
+        fix_versions_field: Some("the-versions".into()),
+        pending_versions_field: Some("the-pending-versions".into()),
     });
     let mut test = new_test_with(jira);
 

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -24,7 +24,8 @@ fn new_test() -> JiraWorkflowTest {
         review_states: Some(vec!["reviewing1".into()]),
         resolved_states: Some(vec!["resolved1".into(), "resolved2".into()]),
         fixed_resolutions: Some(vec!["it-is-fixed".into()]),
-        fix_version_field: Some("the-versions".into()),
+        fix_versions_field: Some("the-versions".into()),
+        pending_versions_field: Some("the-pending-versions".into()),
     };
 
     JiraWorkflowTest {
@@ -192,4 +193,16 @@ fn test_add_version() {
     test.jira.mock_assign_fix_version("SER-1", "5.6.7", Ok(()));
 
     jira::workflow::add_version(Some("5.6.7"), &vec![commit], &projects, &test.jira);
+}
+
+#[test]
+fn test_add_pending_version() {
+    let test = new_test();
+    let projects = vec!["SER".to_string(), "CLI".to_string()];
+    let commit = new_push_commit("Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45][OTHER-999]", "aabbccddee");
+
+    test.jira.mock_add_pending_version("CLI-45", "5.6.7", Ok(()));
+    test.jira.mock_add_pending_version("SER-1", "5.6.7", Ok(()));
+
+    jira::workflow::add_pending_version(Some("5.6.7"), &vec![commit], &projects, &test.jira);
 }


### PR DESCRIPTION
This way it is more well formed than scouring through comment
fields when we want to cut a new version, but avoids multiplication
of versions and keeps those for official versions in testing/release.