### PR TITLE
Add a UI for version merge workflow

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -33,6 +33,7 @@
       <div style="float: right">
         <a ui-sref="users">Users</a> |
         <a ui-sref="repos">Repos</a> |
+        <a ui-sref="versions">Versions</a> |
         <a href ng-click="logout()">Logout</a>
       </div>
     </div>

--- a/src/assets/versions.html
+++ b/src/assets/versions.html
@@ -1,0 +1,56 @@
+<h2>Versions</h2>
+
+<p class="lead">
+  Merge pending versions into new JIRA version
+</p>
+
+<form class="" ng-submit="submit()">
+  <div class="form-group">
+    <input type="text" class="form-control" ng-disabled="!dryRun" ng-model="req.project" placeholder="JIRA project (e.g. SERVER)" required>
+  </div>
+  <div class="form-group">
+    <input type="text" class="form-control" ng-disabled="!dryRun" ng-model="req.version" placeholder="New Version (e.g. 2.1.0.1000)" pattern="((\d+)\.){2,3}\d+" required>
+  </div>
+  <div class="form-group">
+    <button type="submit" ng-disabled="processing || (!dryRun && !hasRespData())" class="btn btn-sm btn-primary">{{submitText()}}</button>
+    <button type="reset" ng-disabled="processing" class="btn btn-sm btn-default" ng-click="reset()">Reset</button>
+  </div>
+</form>
+
+<div ng-hide="dryRun">
+
+  <h3>Preview</h3>
+
+  <div ng-hide="hasRespData()">
+    <i>No versions found to merge</i>
+  </div>
+
+  <div ng-show="hasRespData()">
+    <p>
+      The following JIRAs were found with pending versions to migrate:
+    </p>
+    <div class="well" ng-repeat="(key, versions) in resp">
+      <h4><a ng-href="{{jiraLink(key)}}" target="_blank">{{key}}</a></h4>
+      <ul>
+        <li ng-repeat="v in versions track by $index">{{v}}</li>
+      </ul>
+    </div>
+  </div>
+
+</div>
+
+<div ng-show="!!lastVersion">
+
+  <h3>Success!</h3>
+
+  <p>
+    The following JIRAs were found with pending versions were migrated to {{lastVersion}}
+  </p>
+  <div class="well" ng-repeat="(key, versions) in lastResp">
+    <h4><a ng-href="{{jiraLink(key)}}" target="_blank">{{key}}</a></h4>
+    <ul>
+      <li ng-repeat="v in versions track by $index">{{v}}</li>
+    </ul>
+  </div>
+
+</div>

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,6 +182,14 @@ impl ConfigModel {
 }
 
 impl JiraConfig {
+    pub fn base_url(&self) -> String {
+        if self.host.starts_with("http") {
+            self.host.clone()
+        } else {
+            format!("https://{}", self.host)
+        }
+    }
+
     pub fn progress_states(&self) -> Vec<String> {
         if let Some(ref states) = self.progress_states {
             states.clone() // hmm. do these w/o a clone?

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -46,6 +46,7 @@ pub fn start(config: Config) -> Result<(), String> {
         login: get "/login.html" => HtmlHandler::new("login.html", include_str!("../../src/assets/login.html")),
         users: get "/users.html" => HtmlHandler::new("users.html", include_str!("../../src/assets/users.html")),
         repos: get "/repos.html" => HtmlHandler::new("repos.html", include_str!("../../src/assets/repos.html")),
+        versions: get "/versions.html" => HtmlHandler::new("versions.html", include_str!("../../src/assets/versions.html")),
         app_js: get "/app.js"    => HtmlHandler::new("app.js", include_str!("../../src/assets/app.js")),
         // auth
         auth_login:  post "/auth/login"  => LoginHandler::new(ui_sessions.clone(), config.clone()),
@@ -58,6 +59,7 @@ pub fn start(config: Config) -> Result<(), String> {
                 api_update_users: post "/api/users" => admin::UpdateUsers::new(config.clone()),
                 api_get_repos:    get  "/api/repos" => admin::GetRepos::new(config.clone()),
                 api_update_repos: post "/api/repos" => admin::UpdateRepos::new(config.clone()),
+                api_merge_versions: post "/api/merge-versions" => admin::MergeVersions::new(config.clone(), jira_session.clone()),
             )
         ),
         // hooks

--- a/tests/mocks/mock_jira.rs
+++ b/tests/mocks/mock_jira.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 use octobot::jira::*;
 use octobot::jira::api::Session;
+use octobot::version;
 
 pub struct MockJira {
     get_transitions_calls: Mutex<Vec< MockCall<Vec<Transition>> >>,
@@ -14,7 +15,7 @@ pub struct MockJira {
     assign_fix_version_calls: Mutex<Vec< MockCall<()> >>,
     add_pending_version_calls: Mutex<Vec< MockCall<()> >>,
     remove_pending_versions_calls: Mutex<Vec< MockCall<()> >>,
-    find_pending_versions_calls: Mutex<Vec< MockCall<HashMap<String, Vec<String>>> >>,
+    find_pending_versions_calls: Mutex<Vec< MockCall<HashMap<String, Vec<version::Version>>> >>,
 }
 
 #[derive(Debug)]
@@ -142,7 +143,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn remove_pending_versions(&self, key: &str, versions: &Vec<String>) -> Result<(), String> {
+    fn remove_pending_versions(&self, key: &str, versions: &Vec<version::Version>) -> Result<(), String> {
         let mut calls = self.remove_pending_versions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to remove_pending_versions");
         let call = calls.remove(0);
@@ -152,7 +153,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn find_pending_versions(&self, proj: &str) -> Result<HashMap<String, Vec<String>>, String> {
+    fn find_pending_versions(&self, proj: &str) -> Result<HashMap<String, Vec<version::Version>>, String> {
         let mut calls = self.find_pending_versions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to find_pending_versions");
         let call = calls.remove(0);
@@ -191,11 +192,11 @@ impl MockJira {
         self.add_pending_version_calls.lock().unwrap().push(MockCall::new(ret, vec![key, version]));
     }
 
-    pub fn mock_remove_pending_versions(&self, key: &str, versions: &Vec<String>, ret: Result<(), String>) {
+    pub fn mock_remove_pending_versions(&self, key: &str, versions: &Vec<version::Version>, ret: Result<(), String>) {
         self.remove_pending_versions_calls.lock().unwrap().push(MockCall::new(ret, vec![key, &format!("{:?}", versions)]));
     }
 
-    pub fn mock_find_pending_versions(&self, proj: &str, ret: Result<HashMap<String, Vec<String>>, String>) {
+    pub fn mock_find_pending_versions(&self, proj: &str, ret: Result<HashMap<String, Vec<version::Version>>, String>) {
         self.find_pending_versions_calls.lock().unwrap().push(MockCall::new(ret, vec![proj]));
     }
 }


### PR DESCRIPTION
Also:
- Change pending versions API to return a version::Version object
  to avoid transforming back and forth with strings resulting in
  invalid comparisons when removing pending versions
- Change Version to contain at least 3 fields instead of 4 to avoid
  creating extra ".0" for workflows that only have a 3-tuple.