### PR TITLE
Allow merging pending versions with existing JIRA version

### DIFF
--- a/src/jira/api.rs
+++ b/src/jira/api.rs
@@ -122,14 +122,7 @@ impl Session for JiraSession {
         }
 
         let req = AddVersionReq { name: version.into(), project: proj.into() };
-        // Versions the way we're using them are probably unique anyway, so don't spend the
-        // extra work to check if it exists first.
-        if let Err(e) = self.client.post::<VoidResp, AddVersionReq>("/version", &req) {
-            if e.find("A version with this name already exists in this project").is_none() {
-                return Err(e);
-            }
-        }
-
+        try!(self.client.post::<VoidResp, AddVersionReq>("/version", &req));
         Ok(())
     }
 


### PR DESCRIPTION
This probably won't be needed in practice, but just in case something
goes wrong while merging pending versions into JIRA versions, make sure
we can run the process again and make sure nothing got stranded.

Also: we no longer get the response body in the error text since hyper
library updated. That's okay since we now have a list of real
versions and can decide whether to create new one or not