### PR TITLE
Fix void HTTP responses

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -38,12 +38,6 @@ pub struct GithubSession {
     user: User,
 }
 
-#[allow(dead_code)]
-#[derive(Deserialize)]
-struct EmptyResponse {
-    empty: Option<String>,
-}
-
 impl GithubSession {
     pub fn new(host: &str, token: &str) -> Result<GithubSession, String> {
         let api_base = if host == "github.com" {
@@ -155,8 +149,7 @@ impl Session for GithubSession {
 
         let body = AssignPR { assignees: assignees };
 
-        self.client.post(&format!("repos/{}/{}/issues/{}/assignees", owner, repo, number),
-                         &body)
+        self.client.post(&format!("repos/{}/{}/issues/{}/assignees", owner, repo, number), &body)
     }
 
     fn comment_pull_request(&self, owner: &str, repo: &str, number: u32, comment: &str)
@@ -167,8 +160,7 @@ impl Session for GithubSession {
         }
         let body = CommentPR { body: comment.to_string() };
 
-        let _: EmptyResponse = try!(self.client.post(&format!("repos/{}/{}/issues/{}/comments", owner, repo, number), &body));
-        Ok(())
+        self.client.post_void(&format!("repos/{}/{}/issues/{}/comments", owner, repo, number), &body)
     }
 
     fn create_branch(&self, owner: &str, repo: &str, branch_name: &str, sha: &str) -> Result<(), String> {
@@ -181,13 +173,11 @@ impl Session for GithubSession {
 
         let body = CreateRef { ref_name: format!("refs/heads/{}", branch_name), sha: sha.into() };
 
-        let _: EmptyResponse = try!(self.client.post(&format!("repos/{}/{}/git/refs", owner, repo), &body));
-        Ok(())
+        self.client.post_void(&format!("repos/{}/{}/git/refs", owner, repo), &body)
     }
 
     fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> Result<(), String> {
-        let _: EmptyResponse = try!(self.client.delete(&format!("repos/{}/{}/git/refs/heads/{}", owner, repo, branch_name)));
-        Ok(())
+        self.client.delete_void(&format!("repos/{}/{}/git/refs/heads/{}", owner, repo, branch_name))
     }
 
     fn get_statuses(&self, owner: &str, repo: &str, ref_name: &str) -> Result<Vec<Status>, String> {
@@ -200,5 +190,3 @@ impl Session for GithubSession {
         Ok(())
     }
 }
-
-

--- a/src/jira/api.rs
+++ b/src/jira/api.rs
@@ -44,13 +44,6 @@ struct AuthResp {
     pub name: String,
 }
 
-// TODO: would be nice to specialize for () return type...
-#[derive(Deserialize)]
-struct VoidResp {
-    pub fix_json_parse: Option<String>,
-}
-
-
 fn lookup_field(field: &str, fields: &Vec<Field>) -> Result<String, String> {
     fields.iter().find(|f| field == f.id || field == f.name)
         .map(|f| f.id.clone())
@@ -106,8 +99,7 @@ impl Session for JiraSession {
     }
 
     fn transition_issue(&self, key: &str, req: &TransitionRequest) -> Result<(), String> {
-        try!(self.client.post::<VoidResp, TransitionRequest>(&format!("/issue/{}/transitions", key), &req));
-        Ok(())
+        self.client.post_void(&format!("/issue/{}/transitions", key), &req)
     }
 
     fn comment_issue(&self, key: &str, comment: &str) -> Result<(), String> {
@@ -129,8 +121,7 @@ impl Session for JiraSession {
         }
 
         let req = AddVersionReq { name: version.into(), project: proj.into() };
-        try!(self.client.post::<VoidResp, AddVersionReq>("/version", &req));
-        Ok(())
+        self.client.post_void("/version", &req)
     }
 
     fn get_versions(&self, proj: &str) -> Result<Vec<Version>, String> {
@@ -145,8 +136,7 @@ impl Session for JiraSession {
             }
         });
 
-        try!(self.client.put::<VoidResp, serde_json::Value>(&format!("/issue/{}", key), &req));
-        Ok(())
+        self.client.put_void(&format!("/issue/{}", key), &req)
     }
 
     fn reorder_version(&self, version: &Version, position: JiraVersionPosition) -> Result<(), String> {
@@ -163,8 +153,7 @@ impl Session for JiraSession {
             },
         };
 
-        try!(self.client.post::<VoidResp, serde_json::Value>(&format!("/version/{}/move", version.id), &req));
-        Ok(())
+        self.client.post_void(&format!("/version/{}/move", version.id), &req)
     }
 
     fn add_pending_version(&self, key: &str, version: &str) -> Result<(), String> {
@@ -190,7 +179,7 @@ impl Session for JiraSession {
                 }
             });
 
-            try!(self.client.put::<VoidResp, serde_json::Value>(&format!("/issue/{}", key), &req));
+            self.client.put_void(&format!("/issue/{}", key), &req)?;
         }
         Ok(())
     }
@@ -213,7 +202,7 @@ impl Session for JiraSession {
                 }
             });
 
-            try!(self.client.put::<VoidResp, serde_json::Value>(&format!("/issue/{}", key), &req));
+            self.client.put_void(&format!("/issue/{}", key), &req)?;
         }
         Ok(())
     }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -1,4 +1,4 @@
-use http_client;
+use http_client::HTTPClient;
 
 // the main object for sending messages to slack
 pub struct Slack {
@@ -81,13 +81,11 @@ impl SlackSender for Slack {
 
         info!("Sending message to #{}", channel);
 
-
-        let client = http_client::HTTPClient::new(&self.webhook_url)
+        let client = HTTPClient::new(&self.webhook_url)
             .with_headers(hashmap!{
                 "Content-Type" => "application/json".to_string(),
             });
 
-        client.post::< http_client::VoidResponse, SlackMessage >("", &slack_msg)?;
-        Ok(())
+        client.post_void("", &slack_msg)
     }
 }


### PR DESCRIPTION
There are times when we want to ignore the response from the server,
whether because we don't care about it, or because it is not
JSON, as it turns out is the case for slack incoming webhooks.

I wanted to do this w/ specialization on VoidResponse, but it looks
like that is not in rust stable yet. There is probably a fancier
way to do this, but this works. :)