### PR TITLE
Prompt for credentials to authenticate version merge

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -254,6 +254,13 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
 
   var jiraBase = null;
 
+  function init() {
+    $scope.reset();
+    $('#auth-modal').on('shown.bs.modal', function () {
+      $('#auth-username').focus()
+    })
+  }
+
   $scope.reset = function() {
     $scope.resp = {};
     $scope.dryRun = true;
@@ -261,6 +268,8 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
     $scope.req = {
       project: "",
       version: "",
+      admin_user: "",
+      admin_pass: "",
     };
 
     $scope.lastVersion = null;
@@ -273,6 +282,8 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
       project: $scope.req.project,
       version: $scope.req.version,
       dry_run: !!dryRun,
+      admin_user: $scope.req.admin_user,
+      admin_pass: $scope.req.admin_pass,
     };
     return sessionHttp.post('/api/merge-versions', req).then(function(resp) {
       $scope.processing = false;
@@ -299,7 +310,6 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
 
   function mergeVersionsForReal() {
     let version = $scope.req.version;
-
     mergeVersions(false).then(function(resp) {
       notificationService.showSuccess('Created new version succesfully');
       $scope.reset();
@@ -315,8 +325,17 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
     if ($scope.dryRun) {
       mergeVersionsDryRun();
     } else{
-      mergeVersionsForReal();
+      $scope.req.admin_user = "";
+      $scope.req.admin_pass = "";
+      $('#auth-modal').modal('show');
     }
+  }
+
+  $scope.modalSubmit = function() {
+      $('#auth-modal').modal('hide');
+      mergeVersionsForReal();
+      $scope.req.admin_user = "";
+      $scope.req.admin_pass = "";
   }
 
   $scope.submitText = function() {
@@ -339,5 +358,5 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
     }
   }
 
-  $scope.reset();
+  init();
 });

--- a/src/assets/versions.html
+++ b/src/assets/versions.html
@@ -54,3 +54,29 @@
   </div>
 
 </div>
+
+<div class="modal fade" tabindex="-1" role="dialog" id="auth-modal">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <form class="" ng-submit="modalSubmit()">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">JIRA authentication</h4>
+        </div>
+        <div class="modal-body">
+          <div class="form-group">
+            <input id="auth-username" type="text" class="form-control" ng-model="req.admin_user" placeholder="username" required>
+          </div>
+          <div class="form-group">
+            <input type="password" class="form-control" ng-model="req.admin_pass" placeholder="password" required>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" ng-click="modalSubmit()">Submit</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -59,7 +59,7 @@ pub fn start(config: Config) -> Result<(), String> {
                 api_update_users: post "/api/users" => admin::UpdateUsers::new(config.clone()),
                 api_get_repos:    get  "/api/repos" => admin::GetRepos::new(config.clone()),
                 api_update_repos: post "/api/repos" => admin::UpdateRepos::new(config.clone()),
-                api_merge_versions: post "/api/merge-versions" => admin::MergeVersions::new(config.clone(), jira_session.clone()),
+                api_merge_versions: post "/api/merge-versions" => admin::MergeVersions::new(config.clone()),
             )
         ),
         // hooks


### PR DESCRIPTION
- Version management requires project admin and it is not so good
  to give a bot project admin everywhere
- Merging versions is a more or less destructive operation and
  it is important to do this carefully -- perhaps an auth prompt
  will slow people down a bit.