### PR TITLE
Fix slack DMs for reviewers on PR comments

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -132,6 +132,8 @@ impl HTTPClient {
                     Ok(buffer)
                 })
                 .map(move |buffer| {
+                    debug!("Response: HTTP {}\n---\n{}\n---", status, String::from_utf8_lossy(&buffer));
+
                     if !status.is_success() {
                         return Err(format!("Failed request to {}: HTTP {}\n---\n{}\n---", path, status,
                                    String::from_utf8_lossy(&buffer)));


### PR DESCRIPTION
github reports these as "issues" instead of pull requests, so the
logic to include the reviewers doesn't kick in, since issues don't
have reviewers.