### PR TITLE
Fix background workers with new async hyper stack

### DIFF
--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -106,7 +106,7 @@ impl SlackMessenger {
         }
 
         if let Err(e) = self.slack.send(req) {
-            error!("Error sending to slack: {:?}", e);
+            error!("Error sending to slack worker: {}", e);
         }
     }
 

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1,4 +1,3 @@
-
 use futures::Stream;
 use futures::future::{self, Future};
 use hyper::{self, StatusCode};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,6 +17,7 @@ use github;
 use github::api::GithubSession;
 use jira;
 use jira::api::JiraSession;
+use server::github_handler::GithubHandlerState;
 use std::sync::Arc;
 
 
@@ -44,9 +45,16 @@ pub fn start(config: Config) -> Result<(), String> {
     };
 
     let ui_sessions = Arc::new(Sessions::new());
+    let github_handler_state = Arc::new(GithubHandlerState::new(config.clone(), github.clone(), jira.clone()));
 
     let server = Http::new()
-        .bind(&addr, move || Ok(OctobotService::new(config.clone(), github.clone(), jira.clone(), ui_sessions.clone())))
+        .bind(&addr, move || {
+            Ok(OctobotService::new(
+                config.clone(),
+                ui_sessions.clone(),
+                github_handler_state.clone(),
+            ))
+        })
         .unwrap();
 
     info!("Listening on port {}", addr);


### PR DESCRIPTION
GithubHandler used to be a singleton but now it is being instantiated
for each new request. Whoops. Need to make sure those workers
are instantiated once and shared across requests.