### PR TITLE
Send messages to all reviewers even post-review

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -29,6 +29,8 @@ pub trait Session: Send + Sync {
 
     fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Commit>, String>;
 
+    fn get_pull_request_reviews(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Review>, String>;
+
     fn assign_pull_request(
         &self,
         owner: &str,
@@ -60,7 +62,7 @@ impl GithubSession {
         };
 
         let client = HTTPClient::new(&api_base).with_headers(hashmap!{
-                "Accept" => "application/vnd.github.black-cat-preview+json, application/vnd.github.v3+json".to_string(),
+                "Accept" => "application/vnd.github.v3+json".to_string(),
                 "Content-Type" => "application/json".to_string(),
                 "Authorization" => format!("Token {}", token),
             });
@@ -155,6 +157,10 @@ impl Session for GithubSession {
 
     fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Commit>, String> {
         self.client.get(&format!("repos/{}/{}/pulls/{}/commits", owner, repo, number))
+    }
+
+    fn get_pull_request_reviews(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Review>, String> {
+        self.client.get(&format!("repos/{}/{}/pulls/{}/reviews", owner, repo, number))
     }
 
     fn assign_pull_request(

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -159,6 +159,7 @@ fn some_pr() -> Option<PullRequest> {
         merge_commit_sha: None,
         assignees: vec![User::new("assign1")],
         requested_reviewers: Some(vec![User::new("joe-reviewer")]),
+        reviews: None,
         head: BranchRef {
             ref_name: "pr-branch".into(),
             sha: "ffff0000".into(),

--- a/tests/mocks/mock_github.rs
+++ b/tests/mocks/mock_github.rs
@@ -14,6 +14,7 @@ pub struct MockGithub {
     create_pr_calls: Mutex<Vec<MockCall<PullRequest>>>,
     get_pr_labels_calls: Mutex<Vec<MockCall<Vec<Label>>>>,
     get_pr_commits_calls: Mutex<Vec<MockCall<Vec<Commit>>>>,
+    get_pr_reviews_calls: Mutex<Vec<MockCall<Vec<Review>>>>,
     assign_pr_calls: Mutex<Vec<MockCall<AssignResponse>>>,
     comment_pr_calls: Mutex<Vec<MockCall<()>>>,
     create_branch_calls: Mutex<Vec<MockCall<()>>>,
@@ -49,6 +50,7 @@ impl MockGithub {
             create_pr_calls: Mutex::new(vec![]),
             get_pr_labels_calls: Mutex::new(vec![]),
             get_pr_commits_calls: Mutex::new(vec![]),
+            get_pr_reviews_calls: Mutex::new(vec![]),
             assign_pr_calls: Mutex::new(vec![]),
             comment_pr_calls: Mutex::new(vec![]),
             create_branch_calls: Mutex::new(vec![]),
@@ -194,6 +196,17 @@ impl Session for MockGithub {
         call.ret
     }
 
+    fn get_pull_request_reviews(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Review>, String> {
+        let mut calls = self.get_pr_reviews_calls.lock().unwrap();
+        assert!(calls.len() > 0, "Unexpected call to get_pull_request_reviews");
+        let call = calls.remove(0);
+        assert_eq!(call.args[0], owner);
+        assert_eq!(call.args[1], repo);
+        assert_eq!(call.args[2], number.to_string());
+
+        call.ret
+    }
+
     fn assign_pull_request(
         &self,
         owner: &str,
@@ -329,6 +342,19 @@ impl MockGithub {
         ret: Result<Vec<Commit>, String>,
     ) {
         self.get_pr_commits_calls.lock().unwrap().push(MockCall::new(
+            ret,
+            vec![owner, repo, &number.to_string()],
+        ));
+    }
+
+    pub fn mock_get_pull_request_reviews(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+        ret: Result<Vec<Review>, String>,
+    ) {
+        self.get_pr_reviews_calls.lock().unwrap().push(MockCall::new(
             ret,
             vec![owner, repo, &number.to_string()],
         ));


### PR DESCRIPTION
GitHub removes reviewers from requested_reviewers when they submit
their review. This means that "requested_reviewers" stop getting
slack DMs after they submit their review and don't see follow-up
comments.

Note: we can also now drop blackcat-preview -- the reviews API is
no longer in preview!