### PR TITLE
Use docker in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
+sudo: required
+services:
+  - docker
 language: rust
-
-rust:
-  - stable
-  - beta
-  - nightly
-
-matrix:
-  allow_failures:
-    - rust: nightly
-
-cache: cargo
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y firejail python
+script: python build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ services:
   - docker
 language: rust
 script: python build.py
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: rust
-
 rust:
   - stable
   - beta
   - nightly
-
 matrix:
   allow_failures:
     - rust: nightly
-
 cache: cargo
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y firejail python

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ services:
 language: rust
 script: python build.py
 branches:
-  only:
-    - master
+  except:
+    - /^octobot-.*-[a-f0-9]{40}$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: rust
+
 rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
+
 cache: cargo
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y firejail python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: rust
+
 rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
+
 cache: cargo
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y firejail python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 octobot
 =======
+[![Build Status](https://travis-ci.org/tanium/octobot.svg?branch=master)](https://travis-ci.org/tanium/octobot)
 
 Octobot wants to make your github and slack lives better by triggering
 more directed pull request notifications to help pull requests from their
@@ -75,7 +76,7 @@ For the octobot github user token, you will need to:
 - Grab the "token" value and put it in the config file.
 
   :rotating_light: **Warning** :rotating_light:
-  
+
   This token has read/write access to your code. Guard it carefully and make sure config.toml is only readable by root.
 
 ### Web UI


### PR DESCRIPTION
- Centralizes dependencies in the docker build
- Runs tests inside docker as we expect octobot to be run
- Tests the Dockerfile construction as well