### PR TITLE
Make backport labels more flexible

### DIFF
--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -764,7 +764,7 @@ impl GithubEventHandler {
             return;
         }
 
-        let re = Regex::new(r"(?i)backport-([\d\.]+)").unwrap();
+        let re = Regex::new(r"(?i)backport-(.+)").unwrap();
         let backport = match re.captures(&label.name) {
             Some(c) => c[1].to_string(),
             None => return,

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -873,6 +873,7 @@ fn test_pull_request_merged_backport_labels() {
             Label::new("other"),
             Label::new("backport-1.0"),
             Label::new("BACKPORT-2.0"),
+            Label::new("BACKport-other-thing"),
             Label::new("non-matching"),
         ]),
     );
@@ -885,7 +886,7 @@ fn test_pull_request_merged_backport_labels() {
         slack::req("@joe.reviewer", msg, attach.clone()),
     ]);
 
-    let expect_thread = test.expect_will_merge_branches(vec!["release/1.0".into(), "release/2.0".into()]);
+    let expect_thread = test.expect_will_merge_branches(vec!["release/1.0".into(), "release/2.0".into(), "release/other-thing".into()]);
 
     let resp = test.handler.handle_event().unwrap();
     assert_eq!((StatusCode::Ok, "pr".into()), resp);


### PR DESCRIPTION
i.e. don't require them to only contain numbers and dots.

cf. #140