### PR TITLE
Create default users and repos files if none exist

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -139,12 +139,12 @@ impl Config {
     }
 
     pub fn reload_users_repos(&self) -> Result<()> {
-        let users = users::load_config(&self.main.users_config_file).map_err(|e| {
-            Error::from(format!("Error reading user config file: {}", e))
-        })?;
-        let repos = repos::load_config(&self.main.repos_config_file).map_err(|e| {
-            Error::from(format!("Error reading repo config file: {}", e))
-        })?;
+        let users = users::load_config(&self.main.users_config_file).unwrap_or(
+            users::UserConfig::from_github_host(&self.github.host)
+        );
+        let repos = repos::load_config(&self.main.repos_config_file).unwrap_or(
+            repos::RepoConfig::from_github_host(&self.github.host)
+        );
 
         *self.users.write().unwrap() = users;
         *self.repos.write().unwrap() = repos;

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -94,6 +94,12 @@ impl RepoConfig {
         RepoConfig { repos: RepoHostMap::new() }
     }
 
+    pub fn from_github_host(host: &str) -> RepoConfig {
+        let mut config = RepoConfig { repos: RepoHostMap::new() };
+        config.repos.insert(host.into(), vec![]);
+        config
+    }
+
     pub fn insert(&mut self, host: &str, repo: &str, channel: &str) {
         self.insert_info(host, RepoInfo::new(repo, channel));
     }

--- a/src/users.rs
+++ b/src/users.rs
@@ -35,6 +35,12 @@ impl UserConfig {
         UserConfig { users: UserHostMap::new() }
     }
 
+    pub fn from_github_host(host: &str) -> UserConfig {
+        let mut config = UserConfig { users: UserHostMap::new() };
+        config.users.insert(host.into(), vec![]);
+        config
+    }
+
     pub fn insert(&mut self, host: &str, git_user: &str, slack_user: &str) {
         self.users.entry(host.to_string()).or_insert(vec![]).push(UserInfo {
             github: git_user.to_string(),


### PR DESCRIPTION
Fixes #154 

Create defaults for users.json and repos.json if none yet exist.
Use the github host from config.toml to initialize them.