### PR TITLE
Stop guessing slack names from github names

### DIFF
--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use config::Config;
 use github;
 use slack::{self, SlackAttachment, SlackRequest};
-use users;
 use util;
 use worker::WorkSender;
 
@@ -94,20 +93,7 @@ impl SlackMessenger {
 
     fn send_to_slackbots(&self, users: Vec<github::User>, msg: &str, attachments: &Vec<SlackAttachment>) {
         for user in users {
-            let slack_ref = match self.config.users().lookup_info(user.login()) {
-                Some(info) => {
-                    if info.mute_direct_messages {
-                        None
-                    } else {
-                        Some(users::mention(info.slack))
-                    }
-                }
-                None => {
-                    Some(self.config.users().slack_user_ref(user.login()))
-                }
-            };
-
-            if let Some(ref slack_ref) = slack_ref {
+            if let Some(slack_ref) = self.config.users().slack_user_mention(&user.login()) {
                 self.send_to_slack(&slack_ref, msg, attachments);
             }
         }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -283,7 +283,7 @@ mod tests {
     use super::*;
     use github;
 
-    pub fn new_test() -> (RepoConfig, TempDir) {
+    fn new_test() -> (RepoConfig, TempDir) {
         let temp_dir = TempDir::new("repos.rs").unwrap();
         let db_file = temp_dir.path().join("db.sqlite3");
         let db = Database::new(&db_file.to_string_lossy()).expect("create temp database");

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -280,7 +280,10 @@ impl GithubEventHandler {
     }
 
     fn slack_user_name(&self, user: &github::User) -> String {
-        self.config.users().slack_user_name(user.login())
+        match self.config.users().slack_user_name(&user.login()) {
+            Some(slack_user) => slack_user.to_string(),
+            None => user.login().to_string(),
+        }
     }
 
     fn pull_request_commits(&self, pull_request: &github::PullRequestLike) -> Vec<github::Commit> {

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -279,6 +279,8 @@ impl GithubEventHandler {
         }
     }
 
+    // This defaults to using the github name if no slack name is configured, since this is not
+    // used for actually sending messages, but just for referring to users in slack messages.
     fn slack_user_name(&self, user: &github::User) -> String {
         match self.config.users().slack_user_name(&user.login()) {
             Some(slack_user) => slack_user.to_string(),

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -95,6 +95,15 @@ fn new_test_with(jira: Option<JiraConfig>) -> GithubHandlerTest {
 
     let mut config = Config::new(db);
 
+    config.users_write().insert("the-pr-owner", "the.pr.owner").unwrap();
+    config.users_write().insert("joe-sender", "joe.sender").unwrap();
+    config.users_write().insert("joe-reviewer", "joe.reviewer").unwrap();
+    config.users_write().insert("smith-reviewer", "smith.reviewer").unwrap();
+    config.users_write().insert("assign1", "assign1").unwrap();
+    config.users_write().insert("assign2", "assign2").unwrap();
+    config.users_write().insert("bob-author", "bob.author").unwrap();
+    config.users_write().insert("mentioned-participant", "mentioned.participant").unwrap();
+
     config
         .repos_write()
         .insert_info(&repos::RepoInfo::new("some-user/some-repo", "the-reviews-channel")


### PR DESCRIPTION
Explicit is better.

Fixes #160