### PR TITLE
Allow things to be backported to master and develop branches

### DIFF
--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -782,7 +782,11 @@ impl GithubEventHandler {
             Some(c) => c[1].to_string(),
             None => return,
         };
-        let target_branch = release_branch_prefix.to_string() + &backport;
+        let target_branch = if backport == "master" || backport == "develop" {
+            backport
+        } else {
+            release_branch_prefix.to_string() + &backport
+        };
 
         let req = pr_merge::req(&self.data.repository, pull_request, &target_branch);
         if let Err(e) = self.pr_merge.send(req) {

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1005,6 +1005,46 @@ fn test_pull_request_merged_retroactively_labeled() {
 }
 
 #[test]
+fn test_pull_request_merged_master_branch() {
+    let mut test = new_test();
+    test.handler.event = "pull_request".into();
+    test.handler.action = "labeled".into();
+    test.handler.data.pull_request = some_pr();
+    if let Some(ref mut pr) = test.handler.data.pull_request {
+        pr.merged = Some(true);
+    }
+    test.handler.data.label = Some(Label::new("backport-master"));
+    test.handler.data.sender = User::new("the-pr-merger");
+
+    let expect_thread = test.expect_will_merge_branches(vec!["master".into()]);
+
+    let resp = test.handler.handle_event().unwrap();
+    assert_eq!((StatusCode::Ok, "pr".into()), resp);
+
+    expect_thread.join().unwrap();
+}
+
+#[test]
+fn test_pull_request_merged_develop_branch() {
+    let mut test = new_test();
+    test.handler.event = "pull_request".into();
+    test.handler.action = "labeled".into();
+    test.handler.data.pull_request = some_pr();
+    if let Some(ref mut pr) = test.handler.data.pull_request {
+        pr.merged = Some(true);
+    }
+    test.handler.data.label = Some(Label::new("backport-develop"));
+    test.handler.data.sender = User::new("the-pr-merger");
+
+    let expect_thread = test.expect_will_merge_branches(vec!["develop".into()]);
+
+    let resp = test.handler.handle_event().unwrap();
+    assert_eq!((StatusCode::Ok, "pr".into()), resp);
+
+    expect_thread.join().unwrap();
+}
+
+#[test]
 fn test_push_no_pr() {
     let mut test = new_test();
     test.handler.event = "push".into();


### PR DESCRIPTION
- Sometimes changes are made on release branches and need to be
  backported to master
- Some projects use develop branches that want to cherry-pick
  things to master ahead of wholesale merges from develop to master.