### PR TITLE
Fix Jira Project Regex (needs to handle digits)

### DIFF
--- a/src/jira/workflow.rs
+++ b/src/jira/workflow.rs
@@ -10,7 +10,7 @@ use jira;
 use jira::Transition;
 
 fn get_jira_keys(strings: Vec<String>, projects: &Vec<String>) -> Vec<String> {
-    let re = Regex::new(r"\b([A-Z]+-[0-9]+)\b").unwrap();
+    let re = Regex::new(r"\b([A-Z0-9]+-[0-9]+)\b").unwrap();
 
     let mut all_keys = vec![];
     for s in strings {
@@ -32,7 +32,7 @@ fn get_jira_keys(strings: Vec<String>, projects: &Vec<String>) -> Vec<String> {
 
 fn get_fixed_jira_keys<T: CommitLike>(commits: &Vec<T>, projects: &Vec<String>) -> Vec<String> {
     // Fix [ABC-123][OTHER-567], [YEAH-999]
-    let re = Regex::new(r"(?i)(?:Fix(?:es|ed)?):?\s*(?-i)((\[?([A-Z]+-[0-9]+)(?:\]|\b)[\s,]*)+)")
+    let re = Regex::new(r"(?i)(?:Fix(?:es|ed)?):?\s*(?-i)((\[?([A-Z0-9]+-[0-9]+)(?:\]|\b)[\s,]*)+)")
         .unwrap();
 
     // first extract jiras with fix markers
@@ -59,7 +59,7 @@ fn get_all_jira_keys<T: CommitLike>(commits: &Vec<T>, projects: &Vec<String>) ->
 }
 
 fn get_jira_project(jira_key: &str) -> &str {
-    let re = Regex::new(r"^([A-Za-z]+)(-[0-9]+)?$").unwrap();
+    let re = Regex::new(r"^([A-Za-z0-9]+)(-[0-9]+)?$").unwrap();
 
     match re.captures(&jira_key) {
         Some(c) => c.get(1).map_or(jira_key, |m| m.as_str()),

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -147,17 +147,17 @@ fn test_resolve_issue_no_resolution() {
 #[test]
 fn test_resolve_issue_with_resolution() {
     let test = new_test();
-    let projects = vec!["SER".to_string(), "CLI".to_string()];
+    let projects = vec!["SER2".to_string(), "CLI".to_string()];
     let commit =
-        new_push_commit("Fix [SER-1] I fixed it.\n\nand it is kinda related to [CLI-45][OTHER-999]", "aabbccddee");
+        new_push_commit("Fix [SER2-1] I fixed it.\n\nand it is kinda related to [CLI-45][OTHER-999]", "aabbccddee");
 
     let comment1 = "Merged into branch release/99: [aabbccd|http://the-commit/aabbccddee]\n\
-                   {quote}Fix [SER-1] I fixed it.{quote}\n\
+                   {quote}Fix [SER2-1] I fixed it.{quote}\n\
                    Included in version 5.6.7";
-    test.jira.mock_comment_issue("SER-1", comment1, Ok(()));
+    test.jira.mock_comment_issue("SER2-1", comment1, Ok(()));
 
     let comment2 = "Referenced by commit merged into branch release/99: [aabbccd|http://the-commit/aabbccddee]\n\
-                   {quote}Fix [SER-1] I fixed it.{quote}\n\
+                   {quote}Fix [SER2-1] I fixed it.{quote}\n\
                    Included in version 5.6.7";
     test.jira.mock_comment_issue("CLI-45", comment2, Ok(()));
 
@@ -186,8 +186,8 @@ fn test_resolve_issue_with_resolution() {
         }),
     });
 
-    test.jira.mock_get_transitions("SER-1", Ok(vec![trans]));
-    test.jira.mock_transition_issue("SER-1", &req, Ok(()));
+    test.jira.mock_get_transitions("SER2-1", Ok(vec![trans]));
+    test.jira.mock_transition_issue("SER2-1", &req, Ok(()));
 
     jira::workflow::resolve_issue("release/99", Some("5.6.7"), &vec![commit], &projects, &test.jira, &test.config);
 }


### PR DESCRIPTION
The regexes used to parse potential JIRA project/ticket references was
alpha only.  This doesn't work for projects like 'MYPROJ2', so this change extends the
[A-Z] regex portion to [A-Z0-9].

Updated a single test to reflect it.   The functions using the regexes
are private functions only otherwise I would have written straight unit
tests.