### PR TITLE
Bring back JIRA comments on PR open

### DIFF
--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -419,6 +419,7 @@ impl GithubEventHandler {
                                 );
 
                                 jira::workflow::submit_for_review(
+                                    &pull_request,
                                     &commits,
                                     &jira_projects,
                                     jira_session.deref(),

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1490,6 +1490,12 @@ fn test_jira_pull_request_opened() {
     ]);
 
     if let Some(ref jira) = test.jira {
+        jira.mock_comment_issue(
+            "SER-1",
+            "Review submitted for branch master: http://the-pr",
+            Ok(()),
+        );
+
         jira.mock_get_issue("SER-1", Ok(new_issue("SER-1")));
 
         jira.mock_get_transitions("SER-1", Ok(vec![new_transition("001", "the-progress")]));


### PR DESCRIPTION
Back by popular demand!

These are not as dangerous anymore due to the commit cap in #182.