### PR TITLE
Add GitHub App support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "coco"
@@ -233,6 +252,11 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "error-chain"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -347,6 +371,21 @@ dependencies = [
 name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jsonwebtoken"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -548,8 +587,21 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -570,6 +622,7 @@ dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonwebtoken 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ldap3 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1193,12 +1246,14 @@ dependencies = [
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5032d51da2741729bfdaeb2664d9b8c6d9fd1e2b90715c660b6def36628499c2"
+"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6962c635d530328acc53ac6a955e83093fedc91c5809dfac1fa60fa470830a37"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
@@ -1217,6 +1272,7 @@ dependencies = [
 "checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
 "checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
@@ -1230,6 +1286,7 @@ dependencies = [
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+"checksum jsonwebtoken 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88f52f9cabcc5a04929df00f52fbec4812f89039d0e71cfd15fe6eb58097c7d8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
@@ -1253,7 +1310,9 @@ dependencies = [
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf434ff6117485dc16478d77a4f5c84eccc9c3645c4da8323b287ad6a15a638"
 "checksum openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad395f1cee51b64a8d07cc8063498dc7554db62d5f3ca87a67f4eed2791d0c8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tokio-rustls = "0.4.0"
 toml = "^0.4"
 unidiff = "0.2.0"
 url = "^1.5"
+jsonwebtoken = "4.0.1"
 
 [dev-dependencies]
 tempdir = "0.3.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,8 @@ pub struct AdminConfig {
 pub struct GithubConfig {
     pub webhook_secret: String,
     pub host: String,
-    pub api_token: String,
+    pub app_id: u32,
+    pub app_key_file: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -168,11 +169,22 @@ impl ConfigModel {
             github: GithubConfig {
                 webhook_secret: String::new(),
                 host: String::new(),
-                api_token: String::new(),
+                app_id: 0,
+                app_key_file: String::new(),
             },
             jira: None,
             ldap: None,
         }
+    }
+}
+
+impl GithubConfig {
+    pub fn app_key(&self) -> Result<Vec<u8>> {
+        let mut file_open = fs::File::open(&self.app_key_file)?;
+
+        let mut contents = vec![];
+        file_open.read_to_end(&mut contents)?;
+        Ok(contents)
     }
 }
 
@@ -270,7 +282,8 @@ clone_root_dir = "./repos"
 [github]
 webhook_secret = "abcd"
 host = "git.company.com"
-api_token = "some-tokens"
+app_id = 2
+app_key_file = "some-file.key"
 "#;
         let config = parse_string(config_str).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,8 +51,9 @@ pub struct AdminConfig {
 pub struct GithubConfig {
     pub webhook_secret: String,
     pub host: String,
-    pub app_id: u32,
-    pub app_key_file: String,
+    pub api_token: Option<String>,
+    pub app_id: Option<u32>,
+    pub app_key_file: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -169,8 +170,9 @@ impl ConfigModel {
             github: GithubConfig {
                 webhook_secret: String::new(),
                 host: String::new(),
-                app_id: 0,
-                app_key_file: String::new(),
+                api_token: None,
+                app_id: None,
+                app_key_file: None,
             },
             jira: None,
             ldap: None,
@@ -180,7 +182,9 @@ impl ConfigModel {
 
 impl GithubConfig {
     pub fn app_key(&self) -> Result<Vec<u8>> {
-        let mut file_open = fs::File::open(&self.app_key_file)?;
+        let key_file = &self.app_key_file.as_ref().expect("expected an app_key_file");
+
+        let mut file_open = fs::File::open(key_file)?;
 
         let mut contents = vec![];
         file_open.read_to_end(&mut contents)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use rusqlite::{Connection, Row, Statement};
 use rusqlite::types::FromSql;
 
-use errors::*;
 use db_migrations;
+use errors::*;
 
 #[derive(Clone)]
 pub struct Database {

--- a/src/force_push.rs
+++ b/src/force_push.rs
@@ -9,7 +9,7 @@ use git::Git;
 use git_clone_manager::GitCloneManager;
 use github;
 use github::Commit;
-use github::api::GithubApp;
+use github::api::GithubSessionFactory;
 use worker;
 
 pub fn comment_force_push(
@@ -195,7 +195,7 @@ pub struct ForcePushRequest {
 
 struct Runner {
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     clone_mgr: Arc<GitCloneManager>,
     thread_pool: ThreadPool,
 }
@@ -218,7 +218,7 @@ pub fn req(
 pub fn new_worker(
     max_concurrency: usize,
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     clone_mgr: Arc<GitCloneManager>,
 ) -> worker::Worker<ForcePushRequest> {
     worker::Worker::new(

--- a/src/git_clone_manager.rs
+++ b/src/git_clone_manager.rs
@@ -12,11 +12,11 @@ use github::api::Session;
 // clones git repos with given github session into a managed directory pool
 pub struct GitCloneManager {
     dir_pool: Arc<DirPool>,
-    github_app: Arc<github::api::GithubApp>,
+    github_app: Arc<github::api::GithubSessionFactory>,
 }
 
 impl GitCloneManager {
-    pub fn new(github_app: Arc<github::api::GithubApp>, config: Arc<Config>) -> GitCloneManager {
+    pub fn new(github_app: Arc<github::api::GithubSessionFactory>, config: Arc<Config>) -> GitCloneManager {
         let clone_root_dir = config.main.clone_root_dir.to_string();
 
         GitCloneManager {

--- a/src/git_clone_manager.rs
+++ b/src/git_clone_manager.rs
@@ -7,45 +7,45 @@ use dir_pool::{DirPool, HeldDir};
 use errors::*;
 use git::Git;
 use github;
+use github::api::Session;
 
 // clones git repos with given github session into a managed directory pool
 pub struct GitCloneManager {
     dir_pool: Arc<DirPool>,
-    github_session: Arc<github::api::Session>,
+    github_app: Arc<github::api::GithubApp>,
 }
 
 impl GitCloneManager {
-    pub fn new(github_session: Arc<github::api::Session>, config: Arc<Config>) -> GitCloneManager {
+    pub fn new(github_app: Arc<github::api::GithubApp>, config: Arc<Config>) -> GitCloneManager {
         let clone_root_dir = config.main.clone_root_dir.to_string();
 
         GitCloneManager {
             dir_pool: Arc::new(DirPool::new(&clone_root_dir)),
-            github_session: github_session.clone(),
+            github_app: github_app.clone(),
         }
     }
 
     pub fn clone(&self, owner: &str, repo: &str) -> Result<HeldDir> {
-        let held_clone_dir = self.dir_pool.take_directory(self.github_session.github_host(), owner, repo);
-        self.clone_repo(owner, repo, &held_clone_dir.dir())?;
+        let session = self.github_app.new_session(owner, repo)?;
+
+        let held_clone_dir = self.dir_pool.take_directory(session.github_host(), owner, repo);
+        self.clone_repo(&session, owner, repo, &held_clone_dir.dir())?;
 
         Ok(held_clone_dir)
     }
 
-    fn clone_repo(&self, owner: &str, repo: &str, clone_dir: &PathBuf) -> Result<()> {
-        let url = format!(
-            "https://{}@{}/{}/{}",
-            self.github_session.user().login(),
-            self.github_session.github_host(),
-            owner,
-            repo
-        );
+    fn clone_repo(&self, session: &github::api::Session, owner: &str, repo: &str, clone_dir: &PathBuf) -> Result<()> {
+        let url =
+            format!("https://x-access-token:{}@{}/{}/{}", session.github_token(), session.github_host(), owner, repo);
 
-        let git = Git::new(self.github_session.github_host(), self.github_session.github_token(), clone_dir);
+        let git = Git::new(session.github_host(), session.github_token(), clone_dir);
 
         if clone_dir.join(".git").exists() {
+            info!("Reusing cloned repo https://{}/{}/{} in {:?}", session.github_host(), owner, repo, clone_dir);
             // prune local tags deleted from remotes: important to avoid stale/bad version tags
             git.run(&["fetch", "--prune", "origin", "+refs/tags/*:refs/tags/*"])?;
         } else {
+            info!("Cloning https://{}/{}/{} into {:?}", session.github_host(), owner, repo, clone_dir);
             if let Err(e) = fs::create_dir_all(&clone_dir) {
                 return Err(format!("Error creating clone directory '{:?}': {}", clone_dir, e).into());
             }

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -3,9 +3,10 @@ use tokio_core::reactor::Remote;
 use errors::*;
 use github::models::*;
 use http_client::HTTPClient;
+use jwt;
 
 pub trait Session: Send + Sync {
-    fn user(&self) -> &User;
+    fn bot_name(&self) -> &str;
     fn github_host(&self) -> &str;
     fn github_token(&self) -> &str;
     fn get_pull_request(&self, owner: &str, repo: &str, number: u32) -> Result<PullRequest>;
@@ -57,22 +58,111 @@ pub trait Session: Send + Sync {
     fn get_timeline(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<TimelineEvent>>;
 }
 
+pub fn api_base(host: &str) -> String {
+    if host == "github.com" {
+        "https://api.github.com".to_string()
+    } else {
+        format!("https://{}/api/v3", host)
+    }
+}
+
+pub struct GithubApp {
+    core_remote: Remote,
+    host: String,
+    app_id: u32,
+    // DER formatted API private key
+    app_key: Vec<u8>,
+    app: Option<App>,
+}
+
+impl GithubApp {
+    pub fn new(core_remote: Remote, host: &str, app_id: u32, app_key: &[u8]) -> Result<GithubApp> {
+        let mut github = GithubApp {
+            core_remote: core_remote,
+            host: host.into(),
+            app_id: app_id,
+            app_key: app_key.into(),
+            app: None,
+        };
+
+        github.app = Some(github.new_client().get("/app").map_err(|e| {
+            Error::from(format!("Error authenticating to github with token: {}", e))
+        })?);
+
+        info!("Logged in as application {}", github.app_name());
+
+        Ok(github)
+    }
+
+    fn app_name(&self) -> String {
+        self.app.clone().map(|a| a.name).unwrap_or(String::new())
+    }
+
+    fn new_client(&self) -> HTTPClient {
+        let jwt_token = jwt::new_token(self.app_id, &self.app_key);
+        HTTPClient::new(self.core_remote.clone(), &api_base(&self.host)).with_headers(hashmap!{
+            "Accept" => "application/vnd.github.machine-man-preview+json".to_string(),
+            "Authorization" => format!("Bearer {}", jwt_token),
+        })
+    }
+
+    pub fn new_token_org(&self, org: &str) -> Result<String> {
+        let client = self.new_client();
+
+        // All we care about for now is the installation id
+        #[derive(Deserialize)]
+        struct Installation {
+            id: u32,
+        }
+        #[derive(Deserialize)]
+        struct AccessToken {
+            token: String,
+        }
+
+        // Lookup the installation id for this org/repo
+        let installation: Installation = client.get(&format!("/orgs/{}/installation", org))?;
+        // Get a new access token for this id
+        let token: AccessToken =
+            client.post(&format!("/installations/{}/access_tokens", installation.id), &String::new())?;
+        Ok(token.token)
+    }
+
+    pub fn new_token(&self, owner: &str, repo: &str) -> Result<String> {
+        let client = self.new_client();
+
+        // All we care about for now is the installation id
+        #[derive(Deserialize)]
+        struct Installation {
+            id: u32,
+        }
+        #[derive(Deserialize)]
+        struct AccessToken {
+            token: String,
+        }
+
+        // Lookup the installation id for this org/repo
+        let installation: Installation = client.get(&format!("/repos/{}/{}/installation", owner, repo))?;
+        // Get a new access token for this id
+        let token: AccessToken =
+            client.post(&format!("/installations/{}/access_tokens", installation.id), &String::new())?;
+        Ok(token.token)
+    }
+
+    pub fn new_session(&self, owner: &str, repo: &str) -> Result<GithubSession> {
+        GithubSession::new(self.core_remote.clone(), &self.host, &self.app_name(), &self.new_token(owner, repo)?)
+    }
+}
+
 pub struct GithubSession {
     client: HTTPClient,
     host: String,
     token: String,
-    user: User,
+    bot_name: String,
 }
 
 impl GithubSession {
-    pub fn new(core_remote: Remote, host: &str, token: &str) -> Result<GithubSession> {
-        let api_base = if host == "github.com" {
-            "https://api.github.com".to_string()
-        } else {
-            format!("https://{}/api/v3", host)
-        };
-
-        let client = HTTPClient::new(core_remote, &api_base).with_headers(hashmap!{
+    pub fn new(core_remote: Remote, host: &str, app_name: &str, token: &str) -> Result<GithubSession> {
+        let client = HTTPClient::new(core_remote, &api_base(host)).with_headers(hashmap!{
                 // Standard accept header is "application/vnd.github.v3+json".
                 // The "mockingbird-preview" allows us to use the timeline api.
                 // cf. https://developer.github.com/enterprise/2.13/v3/issues/timeline/
@@ -81,14 +171,9 @@ impl GithubSession {
                 "Authorization" => format!("Token {}", token),
             });
 
-        // make sure we can auth as this user befor handing out session.
-        let user: User = client.get("/user").map_err(|e| {
-            Error::from(format!("Error authenticating to github with token: {}", e))
-        })?;
-
         Ok(GithubSession {
             client: client,
-            user: user,
+            bot_name: app_name.to_string() + "[bot]",
             host: host.to_string(),
             token: token.to_string(),
         })
@@ -96,8 +181,8 @@ impl GithubSession {
 }
 
 impl Session for GithubSession {
-    fn user(&self) -> &User {
-        return &self.user;
+    fn bot_name(&self) -> &str {
+        &self.bot_name
     }
 
     fn github_host(&self) -> &str {

--- a/src/github/models.rs
+++ b/src/github/models.rs
@@ -83,6 +83,12 @@ impl HookBody {
     }
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct App {
+    pub id: u32,
+    pub owner: User,
+    pub name: String,
+}
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct User {
@@ -121,6 +127,7 @@ pub struct Repo {
     pub full_name: String,
     pub name: String,
     pub owner: User,
+    pub archived: Option<bool>,
 }
 
 impl Repo {
@@ -130,6 +137,7 @@ impl Repo {
             full_name: String::new(),
             name: String::new(),
             owner: User::new(""),
+            archived: Some(false),
         }
     }
 
@@ -151,7 +159,12 @@ impl Repo {
             full_name: format!("{}/{}", user, repo),
             name: repo.to_string(),
             owner: User::new(user),
+            archived: Some(false),
         })
+    }
+
+    pub fn archived(&self) -> bool {
+        self.archived.unwrap_or(false)
     }
 }
 
@@ -181,6 +194,7 @@ pub trait PullRequestLike {
     fn title(&self) -> &str;
     fn html_url(&self) -> &str;
     fn number(&self) -> u32;
+    fn has_commits(&self) -> bool;
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -255,6 +269,10 @@ impl<'a> PullRequestLike for &'a PullRequest {
     fn number(&self) -> u32 {
         self.number
     }
+
+    fn has_commits(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -285,6 +303,10 @@ impl<'a> PullRequestLike for &'a Issue {
 
     fn number(&self) -> u32 {
         self.number
+    }
+
+    fn has_commits(&self) -> bool {
+        false
     }
 }
 

--- a/src/jira/api.rs
+++ b/src/jira/api.rs
@@ -95,9 +95,9 @@ impl JiraSession {
 
 impl Session for JiraSession {
     fn get_issue(&self, key: &str) -> Result<Issue> {
-        self.client
-            .get::<Issue>(&format!("/issue/{}", key))
-            .map_err(|e| Error::from(format!("Error creating getting issue [{}]: {}", key, e)))
+        self.client.get::<Issue>(&format!("/issue/{}", key)).map_err(|e| {
+            Error::from(format!("Error creating getting issue [{}]: {}", key, e))
+        })
     }
 
     fn get_transitions(&self, key: &str) -> Result<Vec<Transition>> {

--- a/src/jira/workflow.rs
+++ b/src/jira/workflow.rs
@@ -116,7 +116,7 @@ pub fn submit_for_review(
         if let Err(e) = jira.comment_issue(
             &key,
             &format!(
-               "Referenced by review submitted for branch {}: {}",
+                "Referenced by review submitted for branch {}: {}",
                 pr.base.ref_name,
                 pr.html_url
             ),
@@ -345,7 +345,7 @@ fn try_get_issue_state(key: &str, jira: &jira::api::Session) -> Option<jira::Sta
         Err(e) => {
             error!("Error getting JIRA [{}] {}", key, e);
             None
-        },
+        }
     }
 }
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,0 +1,21 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use jsonwebtoken::{self, Algorithm, Header};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    iat: u64,
+    exp: u64,
+    iss: String,
+}
+
+pub fn new_token(app_id: u32, app_key_der: &[u8]) -> String {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let claims = Claims {
+        iat: now,
+        exp: now + (9 * 60),
+        iss: app_id.to_string(),
+    };
+
+    return jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, app_key_der).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate error_chain;
 extern crate futures;
 extern crate hyper;
 extern crate hyper_rustls;
+extern crate jsonwebtoken;
 extern crate ldap3;
 #[macro_use]
 extern crate maplit;
@@ -43,6 +44,7 @@ pub mod github;
 pub mod http_client;
 pub mod ldap_auth;
 pub mod jira;
+pub mod jwt;
 pub mod messenger;
 pub mod pr_merge;
 pub mod repos;

--- a/src/pr_merge.rs
+++ b/src/pr_merge.rs
@@ -9,13 +9,13 @@ use errors::*;
 use git::Git;
 use git_clone_manager::GitCloneManager;
 use github;
-use github::api::{GithubApp, Session};
+use github::api::{GithubSessionFactory, Session};
 use messenger;
 use slack::{SlackAttachmentBuilder, SlackRequest};
 use worker::{self, WorkSender};
 
 fn clone_and_merge_pull_request(
-    github_app: &GithubApp,
+    github_app: &GithubSessionFactory,
     clone_mgr: &GitCloneManager,
     owner: &str,
     repo: &str,
@@ -169,7 +169,7 @@ pub struct PRMergeRequest {
 
 struct Runner {
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,
     thread_pool: ThreadPool,
@@ -186,7 +186,7 @@ pub fn req(repo: &github::Repo, pull_request: &github::PullRequest, target_branc
 pub fn new_worker(
     max_concurrency: usize,
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,
 ) -> worker::Worker<PRMergeRequest> {

--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -12,6 +12,7 @@ use errors::*;
 use git::Git;
 use git_clone_manager::GitCloneManager;
 use github;
+use github::api::{GithubApp, Session};
 use jira;
 use messenger;
 use slack::{SlackAttachmentBuilder, SlackRequest};
@@ -24,7 +25,7 @@ pub fn comment_repo_version(
     version_script: &str,
     jira_config: &JiraConfig,
     jira: &jira::api::Session,
-    github: &github::api::Session,
+    github_app: &GithubApp,
     clone_mgr: &GitCloneManager,
     owner: &str,
     repo: &str,
@@ -34,6 +35,7 @@ pub fn comment_repo_version(
     jira_projects: &Vec<String>,
     jira_versions_enabled: bool,
 ) -> Result<()> {
+    let github = github_app.new_session(owner, repo)?;
     let held_clone_dir = clone_mgr.clone(owner, repo)?;
     let clone_dir = held_clone_dir.dir();
 
@@ -148,7 +150,7 @@ pub struct RepoVersionRequest {
 
 struct Runner {
     config: Arc<Config>,
-    github_session: Arc<github::api::Session>,
+    github_app: Arc<GithubApp>,
     jira_session: Option<Arc<jira::api::Session>>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,
@@ -172,7 +174,7 @@ pub fn req(
 pub fn new_worker(
     max_concurrency: usize,
     config: Arc<Config>,
-    github_session: Arc<github::api::Session>,
+    github_app: Arc<GithubApp>,
     jira_session: Option<Arc<jira::api::Session>>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,
@@ -181,7 +183,7 @@ pub fn new_worker(
         "repo-version",
         Runner {
             config: config,
-            github_session: github_session,
+            github_app: github_app,
             jira_session: jira_session,
             clone_mgr: clone_mgr,
             slack: slack,
@@ -195,7 +197,7 @@ pub fn new_worker(
 
 impl worker::Runner<RepoVersionRequest> for Runner {
     fn handle(&self, req: RepoVersionRequest) {
-        let github_session = self.github_session.clone();
+        let github_app = self.github_app.clone();
         let jira_session = self.jira_session.clone();
         let clone_mgr = self.clone_mgr.clone();
         let config = self.config.clone();
@@ -221,7 +223,7 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                             &version_script,
                             jira_config,
                             jira,
-                            github_session.borrow(),
+                            github_app.borrow(),
                             &clone_mgr,
                             &req.repo.owner.login(),
                             &req.repo.name,

--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -12,7 +12,7 @@ use errors::*;
 use git::Git;
 use git_clone_manager::GitCloneManager;
 use github;
-use github::api::{GithubApp, Session};
+use github::api::{GithubSessionFactory, Session};
 use jira;
 use messenger;
 use slack::{SlackAttachmentBuilder, SlackRequest};
@@ -25,7 +25,7 @@ pub fn comment_repo_version(
     version_script: &str,
     jira_config: &JiraConfig,
     jira: &jira::api::Session,
-    github_app: &GithubApp,
+    github_app: &GithubSessionFactory,
     clone_mgr: &GitCloneManager,
     owner: &str,
     repo: &str,
@@ -150,7 +150,7 @@ pub struct RepoVersionRequest {
 
 struct Runner {
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     jira_session: Option<Arc<jira::api::Session>>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,
@@ -174,7 +174,7 @@ pub fn req(
 pub fn new_worker(
     max_concurrency: usize,
     config: Arc<Config>,
-    github_app: Arc<GithubApp>,
+    github_app: Arc<GithubSessionFactory>,
     jira_session: Option<Arc<jira::api::Session>>,
     clone_mgr: Arc<GitCloneManager>,
     slack: WorkSender<SlackRequest>,

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -27,7 +27,7 @@ use worker::{WorkSender, Worker};
 
 pub struct GithubHandlerState {
     pub config: Arc<Config>,
-    pub github_app: Arc<github::api::GithubApp>,
+    pub github_app: Arc<github::api::GithubSessionFactory>,
     pub jira_session: Option<Arc<jira::api::Session>>,
     pr_merge_worker: Worker<PRMergeRequest>,
     repo_version_worker: Worker<RepoVersionRequest>,
@@ -61,7 +61,7 @@ const MAX_COMMITS_FOR_JIRA_CONSIDERATION: usize = 20;
 impl GithubHandlerState {
     pub fn new(
         config: Arc<Config>,
-        github_app: Arc<github::api::GithubApp>,
+        github_app: Arc<github::api::GithubSessionFactory>,
         jira_session: Option<Arc<jira::api::Session>>,
         core_remote: Remote,
     ) -> GithubHandlerState {
@@ -107,7 +107,7 @@ impl GithubHandlerState {
 impl GithubHandler {
     pub fn new(
         config: Arc<Config>,
-        github_app: Arc<github::api::GithubApp>,
+        github_app: Arc<github::api::GithubSessionFactory>,
         jira_session: Option<Arc<jira::api::Session>>,
         core_remote: Remote,
     ) -> Box<GithubHandler> {

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -14,6 +14,7 @@ use force_push::{self, ForcePushRequest};
 use git_clone_manager::GitCloneManager;
 use github;
 use github::CommentLike;
+use github::api::Session;
 use jira;
 use messenger::{self, Messenger};
 use pr_merge::{self, PRMergeRequest};
@@ -26,9 +27,8 @@ use worker::{WorkSender, Worker};
 
 pub struct GithubHandlerState {
     pub config: Arc<Config>,
-    pub github_session: Arc<github::api::Session>,
+    pub github_app: Arc<github::api::GithubApp>,
     pub jira_session: Option<Arc<jira::api::Session>>,
-    git_clone_manager: Arc<GitCloneManager>,
     pr_merge_worker: Worker<PRMergeRequest>,
     repo_version_worker: Worker<RepoVersionRequest>,
     force_push_worker: Worker<ForcePushRequest>,
@@ -51,7 +51,6 @@ pub struct GithubEventHandler {
     pub pr_merge: WorkSender<PRMergeRequest>,
     pub repo_version: WorkSender<RepoVersionRequest>,
     pub force_push: WorkSender<ForcePushRequest>,
-    pub git_clone_manager: Arc<GitCloneManager>,
 }
 
 const MAX_CONCURRENT_MERGES: usize = 20;
@@ -62,25 +61,25 @@ const MAX_COMMITS_FOR_JIRA_CONSIDERATION: usize = 20;
 impl GithubHandlerState {
     pub fn new(
         config: Arc<Config>,
-        github_session: Arc<github::api::Session>,
+        github_app: Arc<github::api::GithubApp>,
         jira_session: Option<Arc<jira::api::Session>>,
         core_remote: Remote,
     ) -> GithubHandlerState {
 
-        let git_clone_manager = Arc::new(GitCloneManager::new(github_session.clone(), config.clone()));
+        let git_clone_manager = Arc::new(GitCloneManager::new(github_app.clone(), config.clone()));
 
         let slack_worker = slack::new_worker(core_remote, &config.main.slack_webhook_url);
         let pr_merge_worker = pr_merge::new_worker(
             MAX_CONCURRENT_MERGES,
             config.clone(),
-            github_session.clone(),
+            github_app.clone(),
             git_clone_manager.clone(),
             slack_worker.new_sender(),
         );
         let repo_version_worker = repo_version::new_worker(
             MAX_CONCURRENT_VERSIONS,
             config.clone(),
-            github_session.clone(),
+            github_app.clone(),
             jira_session.clone(),
             git_clone_manager.clone(),
             slack_worker.new_sender(),
@@ -88,15 +87,14 @@ impl GithubHandlerState {
         let force_push_worker = force_push::new_worker(
             MAX_CONCURRENT_FORCE_PUSH,
             config.clone(),
-            github_session.clone(),
+            github_app.clone(),
             git_clone_manager.clone(),
         );
 
         GithubHandlerState {
             config: config.clone(),
-            github_session: github_session.clone(),
+            github_app: github_app.clone(),
             jira_session: jira_session.clone(),
-            git_clone_manager: git_clone_manager.clone(),
             pr_merge_worker: pr_merge_worker,
             repo_version_worker: repo_version_worker,
             force_push_worker: force_push_worker,
@@ -109,11 +107,11 @@ impl GithubHandlerState {
 impl GithubHandler {
     pub fn new(
         config: Arc<Config>,
-        github_session: Arc<github::api::Session>,
+        github_app: Arc<github::api::GithubApp>,
         jira_session: Option<Arc<jira::api::Session>>,
         core_remote: Remote,
     ) -> Box<GithubHandler> {
-        let state = GithubHandlerState::new(config, github_session, jira_session, core_remote);
+        let state = GithubHandlerState::new(config, github_app, jira_session, core_remote);
         GithubHandler::from_state(Arc::new(state))
     }
 
@@ -150,9 +148,8 @@ impl Handler for GithubHandler {
         };
 
         let headers = req.headers().clone();
-        let github_session = self.state.github_session.clone();
+        let github_app = self.state.github_app.clone();
         let config = self.state.config.clone();
-        let git_clone_manager = self.state.git_clone_manager.clone();
         let jira_session = self.state.jira_session.clone();
         let pr_merge = self.state.pr_merge_worker.new_sender();
         let repo_version = self.state.repo_version_worker.new_sender();
@@ -172,6 +169,22 @@ impl Handler for GithubHandler {
                     return Response::new().with_status(StatusCode::BadRequest).with_body(
                         format!("Error parsing JSON: {}", e),
                     );
+                }
+            };
+
+            let github_session = match github_app.new_session(&data.repository.owner.login(), &data.repository.name) {
+                // Note: this doesn't really need to be an Arc anymore...
+                Ok(g) => Arc::new(g),
+                Err(e) => {
+                    error!(
+                        "Error creating a new github session for {}/{}: {}",
+                        data.repository.owner.login(),
+                        &data.repository.name,
+                        e
+                    );
+                    return Response::new().with_status(StatusCode::BadRequest).with_body(format!(
+                        "Could not create github session"
+                    ));
                 }
             };
 
@@ -237,7 +250,6 @@ impl Handler for GithubHandler {
                 config: config.clone(),
                 messenger: messenger::new(config.clone(), slack),
                 github_session: github_session,
-                git_clone_manager: git_clone_manager,
                 jira_session: jira_session,
                 pr_merge: pr_merge,
                 repo_version: repo_version,
@@ -294,6 +306,10 @@ impl GithubEventHandler {
     }
 
     fn pull_request_commits(&self, pull_request: &github::PullRequestLike) -> Vec<github::Commit> {
+        if !pull_request.has_commits() {
+            return vec![];
+        }
+
         match self.github_session.get_pull_request_commits(
             &self.data.repository.owner.login(),
             &self.data.repository.name,
@@ -410,7 +426,12 @@ impl GithubEventHandler {
                                     "Too many commits on Pull Request #{}. Ignoring JIRAs.",
                                     pull_request.number
                                 );
-                                self.messenger.send_to_owner(&msg, &attachments, &pull_request.user, &self.data.repository);
+                                self.messenger.send_to_owner(
+                                    &msg,
+                                    &attachments,
+                                    &pull_request.user,
+                                    &self.data.repository,
+                                );
 
                             } else {
                                 let jira_projects = self.config.repos().jira_projects(
@@ -528,8 +549,8 @@ impl GithubEventHandler {
             return;
         }
 
-        if comment.user().login() == self.github_session.user().login() {
-            info!("Ignoring message from octobot ({}): {}", self.github_session.user().login(), comment.body());
+        if comment.user().login() == self.github_session.bot_name() {
+            info!("Ignoring message from octobot ({}): {}", self.github_session.bot_name(), comment.body());
             return;
         }
 

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -15,7 +15,6 @@ use tokio_rustls;
 use config::Config;
 use errors::*;
 use github;
-use github::api::GithubApp;
 use jira;
 use jira::api::JiraSession;
 use server::github_handler::GithubHandlerState;
@@ -42,15 +41,28 @@ pub fn start(config: Config) -> Result<()> {
     }));
     let core_remote = core_rx.recv().expect("recv core handle");
 
-    let github: Arc<github::api::GithubApp> = match GithubApp::new(
-        core_remote.clone(),
-        &config.github.host,
-        config.github.app_id,
-        &config.github.app_key()?,
-    ) {
-        Ok(s) => Arc::new(s),
-        Err(e) => panic!("Error initiating github session: {}", e),
-    };
+    let github: Arc<github::api::GithubSessionFactory>;
+
+    if config.github.app_id.is_some() {
+        github = match github::api::GithubApp::new(
+            core_remote.clone(),
+            &config.github.host,
+            config.github.app_id.expect("expected an app_id"),
+            &config.github.app_key()?,
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => panic!("Error initiating github session: {}", e),
+        };
+    } else {
+        github = match github::api::GithubOauthApp::new(
+            core_remote.clone(),
+            &config.github.host,
+            &config.github.api_token.as_ref().expect("expected an api_token"),
+        ) {
+            Ok(s) => Arc::new(s),
+            Err(e) => panic!("Error initiating github session: {}", e),
+        };
+    }
 
     let jira: Option<Arc<jira::api::Session>>;
     if let Some(ref jira_config) = config.jira {

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -101,7 +101,6 @@ impl Slack {
         }
 
         info!("Sending message to #{}", channel);
-
         self.client.spawn(self.client.post_void_async("", &slack_msg).then(|res| {
             match res {
                 Ok(_) => info!("Successfully sent slack message"),
@@ -136,7 +135,9 @@ pub fn req(channel: &str, msg: &str, attachments: Vec<SlackAttachment>) -> Slack
     }
 }
 
-pub fn new_worker(core_remote: Remote, webhook_url: &str) -> worker::Worker<SlackRequest> {
+pub type SlackWorker = worker::Worker<SlackRequest>;
+
+pub fn new_worker(core_remote: Remote, webhook_url: &str) -> SlackWorker {
     worker::Worker::new("slack", Runner { slack: Arc::new(Slack::new(core_remote, webhook_url)) })
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-
 use std;
 use std::collections::HashMap;
 use std::sync::mpsc::{self, Receiver};

--- a/tests/mocks/mock_github.rs
+++ b/tests/mocks/mock_github.rs
@@ -6,7 +6,6 @@ use octobot::github::*;
 use octobot::github::api::Session;
 
 pub struct MockGithub {
-    user: User,
     host: String,
     token: String,
 
@@ -44,7 +43,6 @@ impl<T> MockCall<T> {
 impl MockGithub {
     pub fn new() -> MockGithub {
         MockGithub {
-            user: User::new("octobot"),
             host: "the-github-host".to_string(),
             token: "the-github-token".to_string(),
 
@@ -124,8 +122,8 @@ impl Drop for MockGithub {
 }
 
 impl Session for MockGithub {
-    fn user(&self) -> &User {
-        &self.user
+    fn bot_name(&self) -> &str {
+        "octobot[bot]"
     }
 
     fn github_host(&self) -> &str {


### PR DESCRIPTION
Expect that octobot now is an GitHub app in order to avoid requiring
a service account and to take advantage of finer-grained controls.