### PR TITLE
Use author from original commit when backporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,6 @@ ENV USER=octobot
 ENV RUST_LOG=info
 
 ENV PATH=$PATH:$HOME/bin
-ENV GIT_AUTHOR_NAME octobot
-ENV GIT_AUTHOR_EMAIL octobot@tanium.com
-ENV GIT_COMMITTER_NAME $GIT_AUTHOR_NAME
-ENV GIT_COMMITTER_EMAIL $GIT_AUTHOR_EMAIL
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["octobot", "/data/config.toml"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -37,11 +37,6 @@ RUN cargo build --release; exit 0
 ADD src /usr/src/app/src
 ADD tests /usr/src/app/tests
 
-ENV GIT_AUTHOR_NAME octobot
-ENV GIT_AUTHOR_EMAIL octobot@tanium.com
-ENV GIT_COMMITTER_NAME $GIT_AUTHOR_NAME
-ENV GIT_COMMITTER_EMAIL $GIT_AUTHOR_EMAIL
-
 RUN cargo build --release
 
 # have to run tests as a CMD so that it can add the right capabilities for tests

--- a/src/git.rs
+++ b/src/git.rs
@@ -100,6 +100,16 @@ impl Git {
         Ok((title, body.join("\n")))
     }
 
+    pub fn get_commit_author(&self, commit_hash: &str) -> Result<(String, String)> {
+        let message = self.run(&["log", "-1", "--pretty=%an\n%ae", commit_hash])?;
+
+        let mut lines = message.lines();
+        let name: String = lines.next().unwrap_or("").into();
+        let email: String = lines.next().unwrap_or("").into();
+
+        Ok((name, email))
+    }
+
     fn do_run(&self, args: &[&str], stdin: Option<&str>) -> Result<String> {
         debug!("Running git with args: {:?}", args);
         let mut cmd = Command::new("git");

--- a/tests/git_helper/temp_git.rs
+++ b/tests/git_helper/temp_git.rs
@@ -42,8 +42,20 @@ impl TempGit {
         test
     }
 
+    pub fn user_name(&self) -> &str {
+        "Test User"
+    }
+
+    pub fn user_email(&self) -> &str {
+        "testy@octobot.com"
+    }
+
     pub fn run_git(&self, args: &[&str]) -> String {
-        self.git.run(args).expect(&format!("Failed running git: `{:?}`", args))
+        let user = format!("user.name={}", self.user_name());
+        let email = format!("user.email={}", self.user_email());
+        let mut full_args = vec!["-c", &user, "-c", &email];
+        full_args.extend(args.iter());
+        self.git.run(&full_args).expect(&format!("Failed running git: `{:?}`", args))
     }
 
     pub fn reclone(&self) {

--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -67,6 +67,11 @@ fn test_pr_merge_basic() {
     let created_pr = pr_merge::merge_pull_request(&git.git, &github, "the-owner", "the-repo", &pr, "release/1.0")
         .unwrap();
 
+    let (user, email) = git.git.get_commit_author("origin/my-feature-branch-1.0").unwrap();
+
+    assert_eq!(user, git.user_name());
+    assert_eq!(email, git.user_email());
+
     assert_eq!(456, created_pr.number);
     assert_eq!("", git.run_git(&["diff", "master", "origin/my-feature-branch-1.0"]));
 }


### PR DESCRIPTION
Rather than needing a separate account for the bot, specify the
same author as the source commit when backporting. This will make
transitioning to a GitHub app easier.