### PR TITLE
Don't request review or assign backport PRs to author

### DIFF
--- a/src/pr_merge.rs
+++ b/src/pr_merge.rs
@@ -73,12 +73,14 @@ pub fn merge_pull_request(
 
     let new_pr = session.create_pull_request(owner, repo, &title, &body, &pr_branch_name, &target_branch)?;
 
-    let assignees: Vec<String> = pull_request.assignees.iter().map(|a| a.login().to_string()).collect();
+    let mut assignees: Vec<String> = pull_request.assignees.iter().map(|a| a.login().to_string()).collect();
+    assignees.retain(|r| r != pull_request.user.login());
     if !assignees.is_empty() {
         session.assign_pull_request(owner, repo, new_pr.number, assignees)?;
     }
 
-    let reviewers: Vec<String> = pull_request.all_reviewers().into_iter().map(|a| a.login().to_string()).collect();
+    let mut reviewers: Vec<String> = pull_request.all_reviewers().into_iter().map(|a| a.login().to_string()).collect();
+    reviewers.retain(|r| r != pull_request.user.login());
     if !reviewers.is_empty() {
         session.request_review(owner, repo, new_pr.number, reviewers)?;
     }

--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -29,9 +29,13 @@ fn test_pr_merge_basic() {
     pr.merge_commit_sha = Some(commit1.clone());
     pr.head = github::BranchRef::new("my-feature-branch");
     pr.base = github::BranchRef::new("master");
-    pr.assignees = vec![github::User::new("user1"), github::User::new("user2")];
+    pr.assignees = vec![github::User::new("user1"), github::User::new("user2"), github::User::new("the-pr-author")];
     pr.requested_reviewers = Some(vec![github::User::new("reviewer1")]);
-    pr.reviews = Some(vec![github::Review::new("fantastic change", github::User::new("reviewer2"))]);
+    pr.reviews = Some(vec![
+        github::Review::new("fantastic change", github::User::new("reviewer2")),
+        github::Review::new("i like to comment on my own PRs", github::User::new("the-pr-author")),
+    ]);
+    pr.user = github::User::new("the-pr-author");
     let pr = pr;
 
     let mut new_pr = github::PullRequest::new();


### PR DESCRIPTION
This may happen if the author of the original PR commented on it
in such a way that it was regarded as a "PR review"