### PR TITLE
Centralize fetching of PR reviewers

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -240,7 +240,7 @@ impl Session for GithubSession {
             });
         let mut pull_request = pull_request?;
 
-        // Alwyas fetch PR's reviewers. Users get removed from requested_reviewers after they submit their review. :cry:
+        // Always fetch PR's reviewers. Users get removed from requested_reviewers after they submit their review. :cry:
         if pull_request.reviews.is_none() {
             match self.get_pull_request_reviews(owner, repo, number) {
                 Ok(r) => pull_request.reviews = Some(r),

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -229,20 +229,6 @@ impl Handler for GithubHandler {
                 data.pull_request = Some(changed_pr);
             }
 
-            // fetch PR's reviewers, they get removed from requested_reviewers after they submit a review. :cry:
-            if let Some(ref mut pull_request) = data.pull_request {
-                if pull_request.reviews.is_none() {
-                    match github_session.get_pull_request_reviews(
-                        &data.repository.owner.login(),
-                        &data.repository.name,
-                        pull_request.number,
-                    ) {
-                        Ok(r) => pull_request.reviews = Some(r),
-                        Err(e) => error!("Error refetching pull request reviews: {}", e),
-                    };
-                }
-            }
-
             let handler = GithubEventHandler {
                 event: event.clone(),
                 data: data,


### PR DESCRIPTION
This is where we should probably start moving to graphql...

Notifications to reviewers were not happening on `push` events
after reviewers had submitted their reviews because they were
removed from `requested_reviewers`, but do not come back by default
in `get_pull_requests` call.