### PR TITLE
Update clone URL when re-using old clone directories

### DIFF
--- a/src/git_clone_manager.rs
+++ b/src/git_clone_manager.rs
@@ -43,6 +43,7 @@ impl GitCloneManager {
         if clone_dir.join(".git").exists() {
             info!("Reusing cloned repo https://{}/{}/{} in {:?}", session.github_host(), owner, repo, clone_dir);
             // prune local tags deleted from remotes: important to avoid stale/bad version tags
+            git.run(&["remote", "set-url", "origin", &url])?;
             git.run(&["fetch", "--prune", "origin", "+refs/tags/*:refs/tags/*"])?;
         } else {
             info!("Cloning https://{}/{}/{} into {:?}", session.github_host(), owner, repo, clone_dir);


### PR DESCRIPTION
The access token used to clone it the previous time may no longer
be valid, so make sure we always update to the latest one.