### PR TITLE
Revert "Remove future::sync::oneshot use"

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,13 +1,15 @@
-use futures::future::{self, Future};
 use futures::Stream;
+use futures::future::Future;
+use futures::sync::oneshot;
 use hyper;
-use hyper::header::USER_AGENT;
 use hyper::{Body, Request};
+use hyper::header::USER_AGENT;
 use hyper_rustls::HttpsConnector;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use serde_json;
 use std::collections::HashMap;
+use tokio;
 
 use errors;
 use errors::*;
@@ -31,6 +33,9 @@ pub struct HTTPResponse<T> {
     pub status: hyper::StatusCode,
 }
 
+type InternalResponseResult = Result<InternalResp>;
+type FutureInternalResponse = oneshot::Receiver<InternalResponseResult>;
+
 impl HTTPClient {
     pub fn new(api_base: &str) -> HTTPClient {
         HTTPClient {
@@ -52,7 +57,7 @@ impl HTTPClient {
         self.request_de::<T, ()>(Method::GET, path, None).map(|res| res.item)
     }
 
-    pub fn get_async<T>(&self, path: &str) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error> + Send
+    pub fn get_async<T>(&self, path: &str) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -63,15 +68,14 @@ impl HTTPClient {
     where
         T: DeserializeOwned + Send + 'static,
     {
-        self.request_de::<T, U>(Method::POST, path, Some(body))
-            .map(|res| res.item)
+        self.request_de::<T, U>(Method::POST, path, Some(body)).map(|res| res.item)
     }
 
     pub fn post_async<T, U: Serialize>(
         &self,
         path: &str,
         body: &U,
-    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error> + Send
+    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -86,7 +90,7 @@ impl HTTPClient {
         &self,
         path: &str,
         body: &U,
-    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> + Send {
+    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> {
         self.request_void_async::<U>(Method::POST, path, Some(body))
     }
 
@@ -94,15 +98,14 @@ impl HTTPClient {
     where
         T: DeserializeOwned + Send + 'static,
     {
-        self.request_de::<T, U>(Method::PUT, path, Some(body))
-            .map(|res| res.item)
+        self.request_de::<T, U>(Method::PUT, path, Some(body)).map(|res| res.item)
     }
 
     pub fn put_async<T, U: Serialize>(
         &self,
         path: &str,
         body: &U,
-    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error> + Send
+    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -117,7 +120,7 @@ impl HTTPClient {
         &self,
         path: &str,
         body: &U,
-    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> + Send {
+    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> {
         self.request_void_async::<U>(Method::PUT, path, Some(body))
     }
 
@@ -125,7 +128,7 @@ impl HTTPClient {
         self.request_void::<()>(Method::DELETE, path, None).map(|_| ())
     }
 
-    pub fn delete_void_async(&self, path: &str) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> + Send {
+    pub fn delete_void_async(&self, path: &str) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> {
         self.request_void_async::<()>(Method::DELETE, path, None)
     }
 
@@ -133,9 +136,9 @@ impl HTTPClient {
     where
         T: DeserializeOwned + Send + 'static,
     {
-        self.request_de_async(method, path, body)
-            .wait()
-            .map_err(|e| Error::from(format!("Error waiting for HTTP response: {}", e)))
+        self.request_de_async(method, path, body).wait().map_err(|e| {
+            Error::from(format!("Error waiting for HTTP response: {}", e))
+        })
     }
 
     pub fn request_raw<U: Serialize>(
@@ -144,15 +147,15 @@ impl HTTPClient {
         path: &str,
         body: Option<&U>,
     ) -> Result<HTTPResponse<Vec<u8>>> {
-        self.request_raw_async(method, path, body)
-            .wait()
-            .map_err(|e| Error::from(format!("Error waiting for HTTP response: {}", e)))
+        self.request_raw_async(method, path, body).wait().map_err(|e| {
+            Error::from(format!("Error waiting for HTTP response: {}", e))
+        })
     }
 
     pub fn request_void<U: Serialize>(&self, method: Method, path: &str, body: Option<&U>) -> Result<HTTPResponse<()>> {
-        self.request_void_async(method, path, body)
-            .wait()
-            .map_err(|e| Error::from(format!("Error waiting for HTTP response: {}", e)))
+        self.request_void_async(method, path, body).wait().map_err(|e| {
+            Error::from(format!("Error waiting for HTTP response: {}", e))
+        })
     }
 
     pub fn request_de_async<T, U: Serialize>(
@@ -160,7 +163,7 @@ impl HTTPClient {
         method: Method,
         path: &str,
         body: Option<&U>,
-    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error> + Send
+    ) -> impl Future<Item = HTTPResponse<T>, Error = errors::Error>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -168,26 +171,29 @@ impl HTTPClient {
         self.request_async(method, &path, body)
             .or_else(|_| Err("HTTP Request was cancelled".into()))
             .and_then(move |res| {
-                if res.status.is_redirection() {
-                    warn!(
-                        "Received redirection when expected to receive data to deserialize. \
-                         Request: {}; Headers: {:?}",
-                        path, res.headers
-                    );
-                }
+                res.and_then(|res| {
+                    if res.status.is_redirection() {
+                        warn!(
+                            "Received redirection when expected to receive data to deserialize. \
+                                 Request: {}; Headers: {:?}",
+                            path,
+                            res.headers
+                        );
+                    }
 
-                serde_json::from_slice::<T>(&res.data)
-                    .map_err(|e| {
-                        format!(
-                            "Error parsing response: {}\n---\n{}\n---",
-                            e,
-                            String::from_utf8_lossy(&res.data)
-                        ).into()
-                    }).map(|obj| HTTPResponse {
-                        item: obj,
-                        headers: res.headers,
-                        status: res.status,
-                    })
+                    serde_json::from_slice::<T>(&res.data)
+                        .map_err(|e| {
+                            format!("Error parsing response: {}\n---\n{}\n---", e, String::from_utf8_lossy(&res.data))
+                                .into()
+                        })
+                        .map(|obj| {
+                            HTTPResponse {
+                                item: obj,
+                                headers: res.headers,
+                                status: res.status,
+                            }
+                        })
+                })
             })
     }
 
@@ -196,13 +202,17 @@ impl HTTPClient {
         method: Method,
         path: &str,
         body: Option<&U>,
-    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> + Send {
+    ) -> impl Future<Item = HTTPResponse<()>, Error = errors::Error> {
         self.request_async(method, path, body)
             .or_else(|_| Err("HTTP Request was cancelled".into()))
-            .map(|res| HTTPResponse {
-                item: (),
-                headers: res.headers,
-                status: res.status,
+            .and_then(|res| {
+                res.map(|r| {
+                    HTTPResponse {
+                        item: (),
+                        headers: r.headers,
+                        status: r.status,
+                    }
+                })
             })
     }
 
@@ -211,22 +221,27 @@ impl HTTPClient {
         method: Method,
         path: &str,
         body: Option<&U>,
-    ) -> impl Future<Item = HTTPResponse<Vec<u8>>, Error = errors::Error> + Send {
+    ) -> impl Future<Item = HTTPResponse<Vec<u8>>, Error = errors::Error> {
         self.request_async(method, path, body)
             .or_else(|_| Err("HTTP Request was cancelled".into()))
-            .map(|res| HTTPResponse {
-                item: res.data.to_vec(),
-                headers: res.headers,
-                status: res.status,
+            .and_then(|res| {
+                res.map(|r| {
+                    HTTPResponse {
+                        item: r.data.to_vec(),
+                        headers: r.headers,
+                        status: r.status,
+                    }
+                })
             })
     }
 
-    fn request_async<U: Serialize>(
-        &self,
-        method: Method,
-        path: &str,
-        body: Option<&U>,
-    ) -> Box<Future<Item = InternalResp, Error = errors::Error> + Send> {
+    fn request_async<U: Serialize>(&self, method: Method, path: &str, body: Option<&U>) -> FutureInternalResponse {
+        let (tx, rx) = oneshot::channel::<InternalResponseResult>();
+
+        let send_future = |it| if let Err(_) = tx.send(it) {
+            error!("Error sending on future channel");
+        };
+
         let url;
         if path.is_empty() {
             url = self.api_base.clone();
@@ -240,7 +255,8 @@ impl HTTPClient {
         let url: hyper::Uri = match url.parse() {
             Ok(u) => u,
             Err(e) => {
-                return Box::new(future::err(format!("Error parsing url: {}: {}", url, e).into()));
+                send_future(Err(format!("Error parsing url: {}: {}", url, e).into()));
+                return rx;
             }
         };
 
@@ -257,64 +273,72 @@ impl HTTPClient {
                 Err(e) => {
                     error!("Skipping invalid header: {} => {}: {}", k, v, e);
                 }
+
             }
         }
 
         let req = match body {
-            Some(body) => match serde_json::to_string(&body) {
-                Ok(j) => req.body(Body::from(j)),
-                Err(e) => {
-                    return Box::new(future::err(format!("Error json-encoding body: {}", e).into()));
+            Some(body) => {
+                match serde_json::to_string(&body) {
+                    Ok(j) => req.body(Body::from(j)),
+                    Err(e) => {
+                        send_future(Err(format!("Error json-encoding body: {}", e).into()));
+                        return rx;
+                    }
                 }
-            },
+            }
             None => req.body(Body::empty()),
         };
         let req = match req {
             Ok(r) => r,
             Err(e) => {
-                return Box::new(future::err(format!("Error building HTTP request: {}", e).into()));
+                send_future(Err(format!("Error building HTTP request: {}", e).into()));
+                return rx;
             }
         };
+
 
         let path = path.to_string();
 
         // TODO: I wonder if these objects are expensive to create and we should be sharing them across requests?
         let client = hyper::Client::builder().build(HttpsConnector::new(4));
 
-        Box::new(
+        tokio::spawn(
             client
                 .request(req)
+                .map_err(|e| {
+                    error!("Error in HTTP request: {}", e);
+                })
                 .and_then(|res| {
                     let status = res.status();
                     let headers = res.headers().clone();
-                    res.into_body().concat2().map(move |buffer| (status, headers, buffer))
-                }).map_err(|e| {
-                    let msg = format!("Error in HTTP request: {}", e);
-                    error!("{}", msg);
-                    msg.into()
-                }).and_then(move |(status, headers, buffer)| {
-                    debug!(
-                        "Response: HTTP {}\n---\n{}\n---",
-                        status,
-                        String::from_utf8_lossy(&buffer)
-                    );
-                    if !status.is_success() && !status.is_redirection() {
-                        future::err(
-                            format!(
-                                "Failed request to {}: HTTP {}\n---\n{}\n---",
-                                path,
-                                status,
-                                String::from_utf8_lossy(&buffer)
-                            ).into(),
-                        )
-                    } else {
-                        future::ok(InternalResp {
-                            data: buffer,
-                            headers: headers,
-                            status: status,
+                    res.into_body()
+                        .concat2()
+                        .map_err(|e| {
+                            error!("Error in HTTP request: {}", e);
                         })
-                    }
+                        .map(move |buffer| {
+                            debug!("Response: HTTP {}\n---\n{}\n---", status, String::from_utf8_lossy(&buffer));
+                            if !status.is_success() && !status.is_redirection() {
+                                send_future(Err(
+                                    format!(
+                                        "Failed request to {}: HTTP {}\n---\n{}\n---",
+                                        path,
+                                        status,
+                                        String::from_utf8_lossy(&buffer)
+                                    ).into(),
+                                ));
+                            } else {
+                                send_future(Ok(InternalResp {
+                                    data: buffer,
+                                    headers: headers,
+                                    status: status,
+                                }));
+                            }
+                        })
                 }),
-        )
+        );
+
+        rx
     }
 }


### PR DESCRIPTION
This reverts commit 6067dfdae8c5292e97469cb73749565da4f762ab, PR #215

Looks like it is actually not allowed to call `wait` here as it
stops this Future from being able to make progress (or at least
it did when I updated tokio).

Really need to make octobot more async throughout...