### PR TITLE
Add support for `-next` release branches

### DIFF
--- a/src/assets/repos.html
+++ b/src/assets/repos.html
@@ -76,6 +76,10 @@
             <label>Release branch prefix</label>
             <input type="text" class="form-control" ng-model="theRepo.release_branch_prefix" placeholder="release/" />
           </div>
+          <div class="form-group">
+            <label>Next branch suffix</label>
+            <input type="text" class="form-control" ng-model="theRepo.next_branch_suffix" placeholder="-next" />
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>

--- a/src/db_migrations.rs
+++ b/src/db_migrations.rs
@@ -6,7 +6,7 @@ const CREATE_VERSIONS: &'static str = r#"
 create table __version ( current_version integer primary key )
 "#;
 
-const MIGRATIONS: [&'static str; 2] = [
+const MIGRATIONS: [&'static str; 3] = [
     r#"
     create table users (
       id integer not null,
@@ -33,6 +33,7 @@ const MIGRATIONS: [&'static str; 2] = [
     );
     "#,
     r#"alter table users add column mute_direct_messages tinyint not null default 0"#,
+    r#"alter table repos add column next_branch_suffix varchar not null default ''"#,
 ];
 
 fn current_version(conn: &Connection) -> Result<Option<i32>> {

--- a/src/migrate-db.rs
+++ b/src/migrate-db.rs
@@ -97,6 +97,7 @@ fn run() -> Result<()> {
                 jira_versions_enabled: info.jira_versions_enabled.unwrap_or(false),
                 version_script: info.version_script.clone().unwrap_or(String::new()),
                 release_branch_prefix: info.release_branch_prefix.clone().unwrap_or(String::new()),
+                next_branch_suffix: String::new(),
             };
 
             if let Err(e) = repos_db.insert_info(&repo) {

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1608,3 +1608,33 @@ fn test_jira_push_triggers_version_script() {
     let resp = test.handler.handle_event().unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
+
+#[test]
+fn test_jira_push_on_next_branch_does_not_trigger_version_script() {
+    let mut test = new_test_with_jira();
+
+    test.config
+        .repos_write()
+        .insert_info(&repos::RepoInfo::new("some-user/versioning-repo", "the-reviews-channel")
+            .with_version_script("echo 1.2.3.4".into())
+            .with_release_branch_prefix("the-release-".into())
+            .with_next_branch_suffix("-the-next".into()))
+        .expect("Failed to add repo");
+
+    // change the repo to an unconfigured one
+    test.handler.data.repository = Repo::parse(
+        &format!("http://{}/some-user/versioning-repo", test.github.github_host()),
+    ).unwrap();
+
+    test.handler.event = "push".into();
+    test.handler.data.ref_name = Some("refs/heads/the-release-1.1-the-next".into());
+    test.handler.data.before = Some("abcdef0000".into());
+    test.handler.data.after = Some("1111abcdef".into());
+    let commits = some_jira_push_commits();
+    test.handler.data.commits = Some(commits.clone());
+
+    // no assertions
+
+    let resp = test.handler.handle_event().unwrap();
+    assert_eq!((StatusCode::OK, "push".into()), resp);
+}


### PR DESCRIPTION
While a release branch is stabilizing, e.g. `release/1.1`, it is
helpful to be able to continue to backport fixes to a `release/1.1-next`
staging release branch.

Generally, here is how the pattern works:
  * Ship release/1.1
  * Branch release/1.1-next from release/1.1
  * Continue to backport important but non-critical changes on release/1.1-next
  * Backport all critical changes directly to release/1.1
  * When release/1.1 is happy, merge release/1.1-next -> release/1.1
  * Repeat.

Benefits:
  * allows changes destined for a future release to continue to get merged in
  * allows merge conflicts to get resolved now rather than
    postponed/stacked/forgotten
  * avoids just leaving lots of PRs open
  * avoids a huge merge party

Specifically, this PR lets octobot know about these `-next` branches so
that versions and JIRAs are not updated when code is merged to avoid
wrong and potentially confusing version information in JIRA.

Note that octobot will still submit "PR submitted on branch ..." comments
to provide some kind of visibility/tracking in JIRA that some
backporting has been done.