### PR TITLE
Strip out previous merge title prefixes

### DIFF
--- a/src/pr_merge.rs
+++ b/src/pr_merge.rs
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn test_make_merge_desc_multi2() {
         let desc = make_merge_desc(
-            (String::from("more_branches->prev_branch: prev_branch->source_branch: Yay, I made a change (#99)"), String::from("")),
+            (String::from("prev_branch->source_branch: more_branches->prev_branch: Yay, I made a change (#99)"), String::from("")),
             "abcdef",
             99,
             "other_branch",


### PR DESCRIPTION
If a change was backported multiple times, then it would end up
with a rather unsightly PR title. This was noticed in particular
with the use of `-next` branches (see #229).

Since backported PR's are already annotated by octobot with the
pull request number, the history of where it was originally
backported from is already maintained. The title should just
indicate the source of this particular backport.