### PR TITLE
Fix github client accept headers

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -110,10 +110,6 @@ impl GithubApp {
             reqwest::header::ACCEPT,
             "application/vnd.github.machine-man-preview+json".parse().unwrap(),
         );
-        headers.append(
-            reqwest::header::ACCEPT,
-            "application/vnd.github.shadow-cat-preview+json".parse().unwrap(),
-        );
         headers.insert(
             reqwest::header::AUTHORIZATION,
             format!("Bearer {}", jwt_token).parse().unwrap(),


### PR DESCRIPTION
Looks like we don't want to add `shadow-cat` for GithubApp::new_client