### PR TITLE
Support restricting Jira comment visibility by role.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,8 @@ pub struct JiraConfig {
     pub fix_versions_field: Option<String>,
     // the field name for where the pending build versions go. expected to be a plain text field
     pub pending_versions_field: Option<String>,
+    // optional name of role to restrict octobot comment visibility. (e.g. "Administrators")
+    pub restrict_comment_visibility_to_role: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ pub struct JiraConfig {
     pub fix_versions_field: Option<String>,
     // the field name for where the pending build versions go. expected to be a plain text field
     pub pending_versions_field: Option<String>,
-    // optional name of role to restrict octobot comment visibility. (e.g. "Administrators")
+    // optional name of role to restrict octobot comment visibility. (e.g. "Developers")
     pub restrict_comment_visibility_to_role: Option<String>,
 }
 

--- a/src/jira/api.rs
+++ b/src/jira/api.rs
@@ -150,9 +150,9 @@ impl Session for JiraSession {
             req.visibility = Some(VisibilityReq {
                 type_name: "role".to_string(),
                 value: r.clone(),
-            })
+            });
 
-            let result = self.client.post_void::<CommentReq>(&format!("/issue/{}/comment", key), &req)
+            let result = self.client.post_void::<CommentReq>(&format!("/issue/{}/comment", key), &req);
             if result.is_ok() {
                 return Ok(());
             }

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -147,6 +147,7 @@ fn new_test_with_jira() -> GithubHandlerTest {
         fixed_resolutions: Some(vec![":boom:".into()]),
         fix_versions_field: Some("the-versions".into()),
         pending_versions_field: Some("the-pending-versions".into()),
+        restrict_comment_visibility_to_role: None,
     });
     let mut test = new_test_with(jira);
 

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -27,6 +27,7 @@ fn new_test() -> JiraWorkflowTest {
         fixed_resolutions: Some(vec!["it-is-fixed".into()]),
         fix_versions_field: Some("the-versions".into()),
         pending_versions_field: Some("the-pending-versions".into()),
+        restrict_comment_visibility_to_role: None,
     };
 
     JiraWorkflowTest {


### PR DESCRIPTION
Jira supports restricting comment visibility to specific user roles. Octobot admins can use this property set restrict comment visibility of PR updates to only interested roles (e.g. "Developers").

I'm new to Rust and would be grateful for any assistance getting this over the finish line.