### PR TITLE
Treat `main` like a main branch, too

### DIFF
--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -630,7 +630,7 @@ impl GithubEventHandler {
             );
             let next_branch_suffix = self.config.repos().next_branch_suffix(&self.data.repository);
 
-            let is_main_branch = branch_name == "master" || branch_name == "develop" ||
+            let is_main_branch = branch_name == "master" || branch_name == "develop" || branch_name == "main" ||
                 branch_name.starts_with(&release_branch_prefix);
 
             let is_next_branch = branch_name.starts_with(&release_branch_prefix) &&
@@ -806,7 +806,7 @@ impl GithubEventHandler {
             Some(c) => c[1].to_string(),
             None => return,
         };
-        let target_branch = if backport == "master" || backport == "develop" {
+        let target_branch = if backport == "master" || backport == "develop" || backport == "main" {
             backport
         } else {
             release_branch_prefix.to_string() + &backport

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1066,6 +1066,24 @@ fn test_pull_request_merged_develop_branch() {
 }
 
 #[test]
+fn test_pull_request_merged_main_branch() {
+    let mut test = new_test();
+    test.handler.event = "pull_request".into();
+    test.handler.action = "labeled".into();
+    test.handler.data.pull_request = some_pr();
+    if let Some(ref mut pr) = test.handler.data.pull_request {
+        pr.merged = Some(true);
+    }
+    test.handler.data.label = Some(Label::new("backport-main"));
+    test.handler.data.sender = User::new("the-pr-merger");
+
+    test.expect_will_merge_branches("release/", vec!["main".into()]);
+
+    let resp = test.handler.handle_event().unwrap();
+    assert_eq!((StatusCode::OK, "pr".into()), resp);
+}
+
+#[test]
 fn test_push_no_pr() {
     let mut test = new_test();
     test.handler.event = "push".into();


### PR DESCRIPTION
- Puts `main` in the same category of branches as `master` and
`develop`.


Note: I have not tested this because I have been unable to get octobot to build with and without this change.