### PR TITLE
Fix JIRA check to check all PR commits on push

### DIFF
--- a/src/jira/check_jira_refs.rs
+++ b/src/jira/check_jira_refs.rs
@@ -2,13 +2,13 @@ use log;
 
 use crate::errors::*;
 use crate::jira;
-use crate::github::{self, CommitLike};
+use crate::github;
 
 const JIRA_REF_CONTEXT: &'static str = "jira";
 
-pub fn check_jira_refs<T: CommitLike>(
+pub fn check_jira_refs(
     pull_request: &github::PullRequest,
-    commits: &Vec<T>,
+    commits: &Vec<github::Commit>,
     projects: &Vec<String>,
     github: &dyn github::api::Session) {
 
@@ -28,9 +28,11 @@ pub fn check_jira_refs<T: CommitLike>(
     }
 }
 
-fn do_check_jira_refs<T: CommitLike>(
+// Note: this requires PR commits, not push commits, because we want to take all PR commits into
+// consideration, not just what was recently pushed.
+fn do_check_jira_refs(
     pull_request: &github::PullRequest,
-    commits: &Vec<T>,
+    commits: &Vec<github::Commit>,
     projects: &Vec<String>,
     github: &dyn github::api::Session) -> Result<()> {
 

--- a/src/server/github_handler.rs
+++ b/src/server/github_handler.rs
@@ -710,13 +710,15 @@ impl GithubEventHandler {
                                     .build(),
                             );
 
+                        let commits = self.pull_request_commits(&pull_request);
+
                         self.messenger.send_to_all(
                             &message,
                             &attachments,
                             &pull_request.user,
                             &self.data.sender,
                             &self.data.repository,
-                            &self.all_participants(&pull_request),
+                            &self.all_participants_with_commits(&pull_request, &commits),
                         );
 
                         if self.data.forced() && self.config.repos().notify_force_push(&self.data.repository) {
@@ -730,14 +732,12 @@ impl GithubEventHandler {
                         }
 
                         // Mark if no JIRA references
-                        if let Some(ref commits) = self.data.commits {
-                            jira::check_jira_refs(
-                                &pull_request,
-                                commits,
-                                &self.config.repos().jira_projects(&self.data.repository, &branch_name),
-                                self.github_session.deref(),
-                            );
-                        }
+                        jira::check_jira_refs(
+                            &pull_request,
+                            &commits,
+                            &self.config.repos().jira_projects(&self.data.repository, &branch_name),
+                            self.github_session.deref(),
+                        );
                     }
                 }
             }

--- a/tests/check_jira_refs_test.rs
+++ b/tests/check_jira_refs_test.rs
@@ -12,11 +12,12 @@ fn new_pr(title: &str) -> github::PullRequest {
     pr
 }
 
-fn new_push_commit(msg: &str) -> github::PushCommit {
-    let mut commit = github::PushCommit::new();
-    commit.message = msg.into();
+fn new_commit(msg: &str) -> github::Commit {
+    let mut commit = github::Commit::new();
+    commit.commit.message = msg.into();
     commit
 }
+
 
 fn expect_pass(git: &MockGithub, pr: &github::PullRequest) {
     git.mock_create_check_run(&pr, &github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Success), Ok(1));
@@ -32,7 +33,7 @@ fn test_check_jira_refs_no_projects() {
     let git = MockGithub::new();
 
     let pr = new_pr("");
-    let commits = vec![new_push_commit("did stuff")];
+    let commits = vec![new_commit("did stuff")];
     let projects = vec![];
 
     // No assertions -- it shouldn't do anything
@@ -45,7 +46,7 @@ fn test_check_jira_refs_chore_commit() {
     let git = MockGithub::new();
 
     let pr = new_pr("chore: Do stuff");
-    let commits = vec![new_push_commit("did stuff")];
+    let commits = vec![new_commit("did stuff")];
     let projects = vec!["SERVER".into()];
 
     // No assertions -- it shouldn't do anything
@@ -58,7 +59,7 @@ fn test_check_jira_refs_build_commit() {
     let git = MockGithub::new();
 
     let pr = new_pr("build: do stuff");
-    let commits = vec![new_push_commit("did stuff")];
+    let commits = vec![new_commit("did stuff")];
     let projects = vec!["SERVER".into()];
 
     // No assertions -- it shouldn't do anything
@@ -71,7 +72,7 @@ fn test_check_jira_refs_mismatch() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
-    let commits = vec![new_push_commit("[SERVER-123] Do stuff")];
+    let commits = vec![new_commit("[SERVER-123] Do stuff")];
     let projects = vec!["CLIENT".into()];
 
     expect_failure(&git, &pr);
@@ -84,7 +85,7 @@ fn test_check_jira_refs_pass() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
-    let commits = vec![new_push_commit("[SERVER-123] Do stuff")];
+    let commits = vec![new_commit("[SERVER-123] Do stuff")];
     let projects = vec!["SERVER".into()];
 
     expect_pass(&git, &pr);
@@ -97,7 +98,7 @@ fn test_check_jira_refs_requires_only_one_ref() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
-    let commits = vec![new_push_commit("[SERVER-123] Do stuff")];
+    let commits = vec![new_commit("[SERVER-123] Do stuff")];
     let projects = vec!["SERVER".into(), "CLIENT".into()];
 
     expect_pass(&git, &pr);
@@ -111,8 +112,8 @@ fn test_check_jira_refs_checks_all_commits() {
 
     let pr = new_pr("Do stuff");
     let commits = vec![
-        new_push_commit("Do stuff"),
-        new_push_commit("Fix [CLIENT-123] whoops, add jira ref"),
+        new_commit("Do stuff"),
+        new_commit("Fix [CLIENT-123] whoops, add jira ref"),
     ];
     let projects = vec!["SERVER".into(), "CLIENT".into()];
 

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -1248,6 +1248,8 @@ fn test_push_force_notify() {
         Ok(some_commits()),
     );
 
+    expect_jira_ref_fail_pr(&test.github, &pr);
+
     let msg = "joe.sender pushed 0 commit(s) to branch some-branch";
     let attach = vec![
         SlackAttachmentBuilder::new("")
@@ -1324,7 +1326,7 @@ fn test_push_force_notify_ignored() {
         "some-other-repo",
         Some("open"),
         None,
-        Ok(vec![pr]),
+        Ok(vec![pr.clone()]),
     );
     test.github.mock_get_pull_request_commits(
         "some-other-user",
@@ -1332,6 +1334,7 @@ fn test_push_force_notify_ignored() {
         32,
         Ok(some_commits()),
     );
+    expect_jira_ref_fail_pr(&test.github, &pr);
 
     let msg = "joe.sender pushed 0 commit(s) to branch some-branch";
     let attach = vec![


### PR DESCRIPTION
Need to consider all commits that belong to the PR on push events,
not just the commits recently pushed.