### PR TITLE
Make jira check neutral

### DIFF
--- a/src/jira/check_jira_refs.rs
+++ b/src/jira/check_jira_refs.rs
@@ -38,7 +38,7 @@ fn do_check_jira_refs(
 
     let mut run = github::CheckRun::new(JIRA_REF_CONTEXT, pull_request, None);
     if jira::workflow::get_all_jira_keys(commits, projects).is_empty() {
-        run = run.completed(github::Conclusion::Failure);
+        run = run.completed(github::Conclusion::Neutral);
 
         let msg: String;
         if projects.len() == 1 {

--- a/tests/check_jira_refs_test.rs
+++ b/tests/check_jira_refs_test.rs
@@ -24,7 +24,7 @@ fn expect_pass(git: &MockGithub, pr: &github::PullRequest) {
 }
 
 fn expect_failure(git: &MockGithub, pr: &github::PullRequest) {
-    git.mock_create_check_run(&pr, &github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Failure), Ok(1));
+    git.mock_create_check_run(&pr, &github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Neutral), Ok(1));
 }
 
 

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -211,7 +211,7 @@ fn expect_jira_ref_fail(git: &MockGithub) {
 }
 
 fn expect_jira_ref_fail_pr(git: &MockGithub, pr: &PullRequest) {
-    git.mock_create_check_run(&pr, &CheckRun::new("jira", &pr, None).completed(Conclusion::Failure), Ok(1));
+    git.mock_create_check_run(&pr, &CheckRun::new("jira", &pr, None).completed(Conclusion::Neutral), Ok(1));
 }
 
 fn expect_jira_ref_pass(git: &MockGithub) {


### PR DESCRIPTION
Needs some more configuration knobs before we can make it a failure.