### PR TITLE
Move the Add User btn above the table: findability

### DIFF
--- a/src/assets/users.html
+++ b/src/assets/users.html
@@ -1,4 +1,7 @@
 <h3>Users</h3>
+  <div style="margin: 10px">
+    <button type="button" class="btn btn-sm btn-primary" ng-click="addUser()">Add user</button>
+  </div>
   <table class="table">
     <tr>
       <th>GitHub Username</th>
@@ -15,9 +18,6 @@
       </td>
     </tr>
   </table>
-  <div style="margin: 10px">
-    <button type="button" class="btn btn-sm btn-primary" ng-click="addUser()">Add user</button>
-  </div>
 </div>
 
 <div class="modal fade" tabindex="-1" role="dialog" id="add-user-modal">


### PR DESCRIPTION
Table gets super long, don't realize you need to scroll to the bottom to find the button.

Put the button at the top instead.

Page in question (before, table follows just below):
![image](https://user-images.githubusercontent.com/12855692/91364480-d3254080-e7cc-11ea-9da2-4012c077c933.png)
