### PR TITLE
Better support for conventional commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "conventional"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f461933c3d7350b755d88f6d35fa256adb2e2eb846c60bcfa242e859dd0e2a"
+dependencies = [
+ "nom",
+ "unicase",
+]
+
+[[package]]
 name = "cookie"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +865,7 @@ name = "octobot"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1",
+ "conventional",
  "env_logger",
  "failure",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ toml = "0.5.0"
 unidiff = "0.3.2"
 url = "1.7.2"
 tokio-threadpool = "0.1.12"
+conventional = "0.5.0"
 
 [dependencies.jsonwebtoken]
 git = "https://github.com/matthauck/jsonwebtoken"

--- a/src/github/models_checks.rs
+++ b/src/github/models_checks.rs
@@ -42,7 +42,7 @@ pub struct CheckRun {
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct CheckOutput {
-    title: Option<String>,
+    pub title: Option<String>,
     summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,

--- a/src/jira/check_jira_refs.rs
+++ b/src/jira/check_jira_refs.rs
@@ -8,8 +8,9 @@ use crate::github;
 const JIRA_REF_CONTEXT: &'static str = "jira";
 
 const ALLOWED_SKIP_TYPES : &'static [&'static str] = &[
-    "chore",
     "build",
+    "chore",
+    "docs",
     "refactor",
     "style",
     "test",

--- a/src/jira/check_jira_refs.rs
+++ b/src/jira/check_jira_refs.rs
@@ -27,30 +27,15 @@ pub fn check_jira_refs(
     }
 
     // Skip PRs titled accordingly.
-    if !conventional_commit_requires_jira(&pull_request.title) {
+    if let Some(commit_type) = conventional_commit_jira_skip_type(&pull_request.title) {
+        if let Err(e) = do_skip_jira_check(pull_request, commit_type, github) {
+            log::error!("Error marking skipped jira refs: {}", e);
+        }
         return;
     }
 
     if let Err(e) = do_check_jira_refs(pull_request, commits, projects, github) {
         log::error!("Error checking jira refs: {}", e);
-    }
-}
-
-fn conventional_commit_requires_jira(title: &str) -> bool {
-    match Commit::new(title) {
-        Ok(commit) => {
-            for t in ALLOWED_SKIP_TYPES {
-                if *t == commit.type_() {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-        Err(_) => {
-            // no conventional commit: require jira
-            true
-        },
     }
 }
 
@@ -76,6 +61,41 @@ fn do_check_jira_refs(
     } else {
         run = run.completed(github::Conclusion::Success);
     }
+
+    github.create_check_run(pull_request, &run)?;
+
+    Ok(())
+}
+
+fn conventional_commit_jira_skip_type(title: &str) -> Option<&str> {
+    match Commit::new(title) {
+        Ok(commit) => {
+            for t in ALLOWED_SKIP_TYPES {
+                if *t == commit.type_() {
+                    return Some(t)
+                }
+            }
+
+            return None;
+        }
+        Err(_) => {
+            // no conventional commit: require jira
+            None
+        },
+    }
+}
+
+fn do_skip_jira_check(
+    pull_request: &github::PullRequest,
+    commit_type: &str,
+    github: &dyn github::api::Session) -> Result<()> {
+
+    let msg = "Skipped JIRA check";
+    let body = format!("Skipped JIRA check for commit type: {}", commit_type);
+
+    let mut run = github::CheckRun::new(JIRA_REF_CONTEXT, pull_request, None);
+    run = run.completed(github::Conclusion::Neutral);
+    run.output = Some(github::CheckOutput::new(&msg, &body));
 
     github.create_check_run(pull_request, &run)?;
 

--- a/tests/check_jira_refs_test.rs
+++ b/tests/check_jira_refs_test.rs
@@ -24,7 +24,17 @@ fn expect_pass(git: &MockGithub, pr: &github::PullRequest) {
 }
 
 fn expect_failure(git: &MockGithub, pr: &github::PullRequest) {
-    git.mock_create_check_run(&pr, &github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Neutral), Ok(1));
+    let mut run = github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Neutral);
+    run.output = Some(github::CheckOutput::new("Missing JIRA reference", ""));
+
+    git.mock_create_check_run(&pr, &run, Ok(1));
+}
+
+fn expect_skip(git: &MockGithub, pr: &github::PullRequest) {
+    let mut run = github::CheckRun::new("jira", &pr, None).completed(github::Conclusion::Neutral);
+    run.output = Some(github::CheckOutput::new("Skipped JIRA check", ""));
+
+    git.mock_create_check_run(&pr, &run, Ok(1));
 }
 
 
@@ -49,7 +59,7 @@ fn test_check_jira_refs_chore_commit() {
     let commits = vec![new_commit("did stuff")];
     let projects = vec!["SERVER".into()];
 
-    // No assertions -- it shouldn't do anything
+    expect_skip(&git, &pr);
 
     jira::check_jira_refs(&pr, &commits, &projects, &git);
 }
@@ -62,7 +72,7 @@ fn test_check_jira_refs_chore_commit_scope() {
     let commits = vec![new_commit("update deps")];
     let projects = vec!["SERVER".into()];
 
-    // No assertions -- it shouldn't do anything
+    expect_skip(&git, &pr);
 
     jira::check_jira_refs(&pr, &commits, &projects, &git);
 }
@@ -75,7 +85,7 @@ fn test_check_jira_refs_build_commit() {
     let commits = vec![new_commit("did stuff")];
     let projects = vec!["SERVER".into()];
 
-    // No assertions -- it shouldn't do anything
+    expect_skip(&git, &pr);
 
     jira::check_jira_refs(&pr, &commits, &projects, &git);
 }

--- a/tests/check_jira_refs_test.rs
+++ b/tests/check_jira_refs_test.rs
@@ -55,6 +55,19 @@ fn test_check_jira_refs_chore_commit() {
 }
 
 #[test]
+fn test_check_jira_refs_chore_commit_scope() {
+    let git = MockGithub::new();
+
+    let pr = new_pr("chore(deps): Update deps");
+    let commits = vec![new_commit("update deps")];
+    let projects = vec!["SERVER".into()];
+
+    // No assertions -- it shouldn't do anything
+
+    jira::check_jira_refs(&pr, &commits, &projects, &git);
+}
+
+#[test]
 fn test_check_jira_refs_build_commit() {
     let git = MockGithub::new();
 

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -223,7 +223,10 @@ fn expect_jira_ref_fail(git: &MockGithub) {
 }
 
 fn expect_jira_ref_fail_pr(git: &MockGithub, pr: &PullRequest) {
-    git.mock_create_check_run(&pr, &CheckRun::new("jira", &pr, None).completed(Conclusion::Neutral), Ok(1));
+    let mut run = CheckRun::new("jira", &pr, None).completed(Conclusion::Neutral);
+    run.output = Some(CheckOutput::new("Missing JIRA reference", ""));
+
+    git.mock_create_check_run(&pr, &run, Ok(1));
 }
 
 fn expect_jira_ref_pass(git: &MockGithub) {

--- a/tests/mocks/mock_github.rs
+++ b/tests/mocks/mock_github.rs
@@ -517,5 +517,10 @@ impl MockGithub {
 }
 
 fn format_check_run(run: &CheckRun) -> String {
-    format!("{}, {:?}", run.name, run.conclusion.as_ref().unwrap_or(&Conclusion::ActionRequired))
+    let output = match &run.output {
+        Some(o) => o.title.as_ref().unwrap_or(&String::new()).clone(),
+        None => String::new(),
+    };
+
+    format!("{}, {:?}, {}", run.name, run.conclusion.as_ref().unwrap_or(&Conclusion::ActionRequired), output)
 }

--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -261,3 +261,74 @@ if (true) {
     assert_eq!(456, created_pr.number);
     assert_eq!(contents_10_final, git.run_git(&["cat-file", "blob", "my-feature-branch-1.0:file.cpp"]));
 }
+
+#[test]
+fn test_pr_merge_conventional_commit() {
+    let git = TempGit::new();
+    let github = MockGithub::new();
+
+    // setup a release branch
+    git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    // make a new commit on master
+    git.run_git(&["checkout", "master"]);
+    git.add_repo_file("file.txt", "contents1", "fix(thing)!: I made a change");
+    let commit1 = git.git.current_commit().unwrap();
+
+    // pretend this came from a PR
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+    pr.assignees = vec![github::User::new("user1"), github::User::new("user2"), github::User::new("the-pr-author")];
+    pr.requested_reviewers = Some(vec![github::User::new("reviewer1")]);
+    pr.reviews = Some(vec![
+        github::Review::new("fantastic change", github::User::new("reviewer2")),
+        github::Review::new("i like to comment on my own PRs", github::User::new("the-pr-author")),
+    ]);
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "fix(thing)!: master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    github.mock_assign_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["user1".into(), "user2".into()],
+        Ok(()),
+    );
+
+    github.mock_request_review(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["reviewer1".into(), "reviewer2".into()],
+        Ok(()),
+    );
+
+    let created_pr = pr_merge::merge_pull_request(&git.git, &github, "the-owner", "the-repo", &pr, "release/1.0", "release/")
+        .unwrap();
+
+    let (user, email) = git.git.get_commit_author("origin/my-feature-branch-1.0").unwrap();
+
+    assert_eq!(user, git.user_name());
+    assert_eq!(email, git.user_email());
+
+    assert_eq!(456, created_pr.number);
+    assert_eq!("", git.run_git(&["diff", "master", "origin/my-feature-branch-1.0"]));
+}


### PR DESCRIPTION
- Add more types that do not require JIRAs
- Add support for scopes and breaking changes with actual
  conventional commit parsing
- Add a neutral check for skipped PRs instead of ignoring altogether
- Make sure backports preserve conventional commit prefix
  before the backport prefix