### PR TITLE
Comment on source PR if backport fails.

### DIFF
--- a/src/pr_merge.rs
+++ b/src/pr_merge.rs
@@ -19,30 +19,72 @@ use crate::worker;
 fn clone_and_merge_pull_request(
     github_app: &dyn GithubSessionFactory,
     clone_mgr: &GitCloneManager,
-    owner: &str,
-    repo: &str,
-    pull_request: &github::PullRequest,
-    target_branch: &str,
-    release_branch_prefix: &str,
-) -> Result<github::PullRequest> {
+    req: &PRMergeRequest,
+    config: Arc<Config>,
+    slack: Arc<dyn worker::Worker<SlackRequest>>,
+) {
+    let owner = &req.repo.owner.login();
+    let repo = &req.repo.name;
 
-    let session = github_app.new_session(owner, repo)?;
-    let held_clone_dir = clone_mgr.clone(owner, repo)?;
+    let session = match github_app.new_session(owner, repo) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Error getting new session: {}", e);
+            return;
+        }
+    };
+    let held_clone_dir = match clone_mgr.clone(owner, repo) {
+        Ok(h) => h,
+        Err(e) => {
+            error!("Error getting new session: {}", e);
+            return;
+        }
+    };
     let clone_dir = held_clone_dir.dir();
     let git = Git::new(session.github_host(), session.github_token(), clone_dir);
 
-    merge_pull_request(&git, &session, owner, repo, pull_request, target_branch, release_branch_prefix)
+    merge_pull_request(&git, &session, &req, config, slack)
 }
 
 pub fn merge_pull_request(
     git: &Git,
     session: &dyn Session,
-    owner: &str,
-    repo: &str,
-    pull_request: &github::PullRequest,
-    target_branch: &str,
-    release_branch_prefix: &str,
+    req: &PRMergeRequest,
+    config: Arc<Config>,
+    slack: Arc<dyn worker::Worker<SlackRequest>>,
+) {
+    if let Err(e) = try_merge_pull_request(git, session, req) {
+        let attach = SlackAttachmentBuilder::new(&format!("{}", e))
+            .title(
+                format!("Source PR: #{}: \"{}\"", req.pull_request.number, req.pull_request.title)
+                    .as_str(),
+            )
+            .title_link(req.pull_request.html_url.clone())
+            .color("danger")
+            .build();
+
+        let messenger = messenger::new(config.clone(), slack.clone());
+        messenger.send_to_owner(
+            &format!(
+                "Error creating merge PR from {} to {}",
+                req.pull_request.head.ref_name,
+                req.target_branch
+            ),
+            &vec![attach],
+            &req.pull_request.user,
+            &req.repo,
+            &req.target_branch,
+            &req.commits,
+        );
+    }
+}
+
+pub fn try_merge_pull_request(
+    git: &Git,
+    session: &dyn Session,
+    req: &PRMergeRequest,
 ) -> Result<github::PullRequest> {
+    let pull_request = &req.pull_request;
     if !pull_request.is_merged() {
         return Err(format_err!("Pull Request #{} is not yet merged.", pull_request.number));
     }
@@ -57,7 +99,7 @@ pub fn merge_pull_request(
     // strip everything before last slash
     let regex = Regex::new(r".*/").unwrap();
     let pr_branch_name =
-        format!("{}-{}", regex.replace(&pull_request.head.ref_name, ""), regex.replace(&target_branch, ""));
+        format!("{}-{}", regex.replace(&pull_request.head.ref_name, ""), regex.replace(&req.target_branch, ""));
 
     // make sure there isn't already such a branch
     let current_remotes = git.run(&["ls-remote", "--heads"])?;
@@ -70,14 +112,16 @@ pub fn merge_pull_request(
         &merge_commit_sha,
         &pr_branch_name,
         pull_request.number,
-        &target_branch,
+        &req.target_branch,
         &pull_request.base.ref_name,
-        release_branch_prefix,
+        &req.release_branch_prefix,
     )?;
 
     git.run(&["push", "origin", &format!("HEAD:{}", pr_branch_name)])?;
 
-    let new_pr = session.create_pull_request(owner, repo, &title, &body, &pr_branch_name, &target_branch)?;
+    let owner = &req.repo.owner.login();
+    let repo = &req.repo.name;
+    let new_pr = session.create_pull_request(owner, repo, &title, &body, &pr_branch_name, &req.target_branch)?;
 
     let mut assignees: Vec<String> = pull_request.assignees.iter().map(|a| a.login().to_string()).collect();
     assignees.retain(|r| r != pull_request.user.login());
@@ -259,40 +303,13 @@ pub fn new_runner(
 
 impl worker::Runner<PRMergeRequest> for Runner {
     fn handle(&self, req: PRMergeRequest) {
-        let merge_result = clone_and_merge_pull_request(
+        clone_and_merge_pull_request(
             self.github_app.borrow(),
             self.clone_mgr.borrow(),
-            &req.repo.owner.login(),
-            &req.repo.name,
-            &req.pull_request,
-            &req.target_branch,
-            &req.release_branch_prefix,
+            &req,
+            self.config.clone(),
+            self.slack.clone(),
         );
-
-        if let Err(e) = merge_result {
-            let attach = SlackAttachmentBuilder::new(&format!("{}", e))
-                .title(
-                    format!("Source PR: #{}: \"{}\"", req.pull_request.number, req.pull_request.title)
-                        .as_str(),
-                )
-                .title_link(req.pull_request.html_url.clone())
-                .color("danger")
-                .build();
-
-            let messenger = messenger::new(self.config.clone(), self.slack.clone());
-            messenger.send_to_owner(
-                &format!(
-                    "Error creating merge PR from {} to {}",
-                    req.pull_request.head.ref_name,
-                    req.target_branch
-                ),
-                &vec![attach],
-                &req.pull_request.user,
-                &req.repo,
-                &req.target_branch,
-                &req.commits,
-            );
-        }
     }
 }
 

--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -39,7 +39,6 @@ fn new_test() -> (PRMergeTest, TempDir) {
             .with_force_push(true))
         .expect("Failed to add some-user/some-repo");
 
-    // todo: configure channels/users
     (PRMergeTest{
         git: TempGit::new(),
         github: MockGithub::new(),

--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -409,6 +409,14 @@ fn test_pr_merge_backport_failure() {
         Err(format_err!("bad stuff")),
     );
 
+    test.github.mock_comment_pull_request(
+        "the-owner",
+        "the-repo",
+        123,
+        "Error creating merge PR from my-feature-branch to release/1.0",
+        Ok(()),
+    );
+
     test.slack.expect(vec![
         slack::req(
             "the-review-channel",


### PR DESCRIPTION
Octobot reports a backport failure via a DM to the PR author, which can
be missed and lost, leaving no persistent record of what happened.

Octobot should additionally comment on the PR itself.

I haven't tested this live, nor via unit tests :grimacing:.

For the former, I tried to create an org in public github but got a bit stumped on how to create an app/get a token.

For the latter, it seemed like I needed to create a full `Runner` in `pr_merge_test`, which hasn't been done before. The runner takes a `GithubSessionFactory`. I tried to create a Mock for that, but since `new_session` returns `Result<GithubSession>` (not `Result<Session>`), I couldn't have my mock return a `MockSession` instead. Here's what I tried:

```diff
diff --git a/tests/mocks/mock_github.rs b/tests/mocks/mock_github.rs
index 8f4f549..17d7fbd 100644
--- a/tests/mocks/mock_github.rs
+++ b/tests/mocks/mock_github.rs
@@ -3,7 +3,28 @@ use std::thread;
 
 use octobot::errors::*;
 use octobot::github::*;
-use octobot::github::api::Session;
+use octobot::github::api::{Session,GithubSession,GithubSessionFactory};
+use mocks::mock_github::MockGithub;
+
+pub struct MockGithubSessionFactory {}
+
+impl GithubSessionFactory for MockGithubSessionFactory {
+    fn bot_name(&self) -> String {
+        "MockBotName".to_string()
+    }
+
+    fn get_token_org(&self, org: &str) -> Result<String> {
+        Ok("MockTokenOrg".to_string())
+    }
+
+    fn get_token_repo(&self, owner: &str, repo: &str) -> Result<String> {
+        Ok("MockTokenRepo".to_string())
+    }
+
+    fn new_session(&self, owner: &str, repo: &str) -> Result<GithubSession> {
+        Ok(MockGithub::new())
+    }
+}
 
 pub struct MockGithub {
     host: String,
diff --git a/tests/pr_merge_test.rs b/tests/pr_merge_test.rs
index 988f708..5e55b85 100644
--- a/tests/pr_merge_test.rs
+++ b/tests/pr_merge_test.rs
@@ -1,10 +1,17 @@
 mod git_helper;
 mod mocks;
 
+use std::sync::Arc;
 use git_helper::temp_git::TempGit;
 use mocks::mock_github::MockGithub;
+use mocks::mock_github::MockGithubSessionFactory;
 use octobot::github;
 use octobot::pr_merge;
+use octobot::config::Config;
+use octobot::db::Database;
+use octobot::git_clone_manager::GitCloneManager;
+use mocks::mock_slack::MockSlack;
+use tempdir::TempDir;
 
 #[test]
 fn test_pr_merge_basic() {
@@ -332,3 +339,22 @@ fn test_pr_merge_conventional_commit() {
     assert_eq!(456, created_pr.number);
     assert_eq!("", git.run_git(&["diff", "master", "origin/my-feature-branch-1.0"]));
 }
+
+#[test]
+fn test_pr_merge_backport_failure() {
+    let git = TempGit::new();
+
+    let temp_dir = TempDir::new("repos.rs").unwrap();
+    let db_file = temp_dir.path().join("db.sqlite3");
+    let db = Database::new(&db_file.to_string_lossy()).expect("create temp database");
+    let config = Arc::new(Config::new(db));
+    let github = Arc::new(MockGithubSessionFactory::new());
+    //let clone_mgr = Arc::new(GitCloneManager::new(github, config));
+    let slack = MockSlack::new(vec![]);
+    let runner = pr_merge::new_runner(
+        config,
+        github,
+        //clone_mgr,
+        slack.new_sender(),
+    );
+}
```

Which errors `expected struct GithubSession, found struct MockGithub`. I don't know enough about Rust to figure this out, but I might try again later. `new_session` returning a `Box` could work, perhaps?
Or I'm on totally the wrong track trying to test this.
