### PR TITLE
Use py3-compatible syntax in test.

### DIFF
--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -339,7 +339,7 @@ mod tests {
         let script_file = sub_dir.join("version.py");
         {
             let mut file = fs::File::create(&script_file).expect("create file");
-            file.write_all(b"print '1.2.3.4'").expect("write file");
+            file.write_all(b"print('1.2.3.4')").expect("write file");
         }
 
         assert_eq!("1.2.3.4", run_script("python version.py", &sub_dir).unwrap());


### PR DESCRIPTION
Since this test invokes `python`, you might get python 2 or 3. `print`
with parens should work on any somewhat recent python (2 or 3).

Fixes:
```
---- repo_version::tests::test_run_python_script stdout ----
thread 'repo_version::tests::test_run_python_script' panicked at 'called `Result::unwrap()` on an `Err` value: ErrorMessage { msg: "Error running version script (exit code 1; script: python version.py):\n\n  File \"/home/rcorre/version.py\", line 1\n    print \'1.2.3.4\'\n          ^\nSyntaxError: Missing parentheses in call to \'print\'. Did you mean print(\'1.2.3.4\')?\n" }', src/repo_version.rs:345:73
```
