### PR TITLE
Fix non_fmt_panic warnings.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,7 +19,7 @@ RUN apt-get update \
   && rm -fr /var/lib/apt/lists/
 
 ENV PATH $PATH:/root/.cargo/bin
-ENV RUST_VERSION 1.47.0
+ENV RUST_VERSION 1.51.0
 
 # install rust
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_VERSION" \

--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -306,9 +306,9 @@ mod tests {
         }
 
         let err = format!("{}", run_script("bash version.sh", &sub_dir).unwrap_err());
-        assert!(err.contains("Error running version script"), err);
-        assert!(err.contains("out-err"), err);
-        assert!(err.contains("err-err"), err);
+        assert!(err.contains("Error running version script"), "{}", err);
+        assert!(err.contains("out-err"), "{}", err);
+        assert!(err.contains("err-err"), "{}", err);
     }
 
     #[test]
@@ -325,8 +325,8 @@ mod tests {
         }
 
         let err = format!("{}", run_script("bash version.sh", &sub_dir).unwrap_err());
-        assert!(err.contains("Error running version script"), err);
-        assert!(err.contains("some error"), err);
+        assert!(err.contains("Error running version script"), "{}", err);
+        assert!(err.contains("some error"), "{}", err);
     }
 
     #[test]

--- a/tests/mocks/mock_jira.rs
+++ b/tests/mocks/mock_jira.rs
@@ -119,7 +119,7 @@ impl Drop for MockJira {
 impl Session for MockJira {
     fn get_issue(&self, key: &str) -> Result<Issue> {
         let mut calls = self.get_issue_calls.lock().unwrap();
-        assert!(calls.len() > 0, format!("Unexpected call to get_issue {}", key));
+        assert!(calls.len() > 0, "Unexpected call to get_issue {}", key);
         let call = calls.remove(0);
         assert_eq!(call.args[0], key);
 

--- a/tests/mocks/mock_worker.rs
+++ b/tests/mocks/mock_worker.rs
@@ -61,7 +61,7 @@ impl<T: PartialEq + Debug + Send + Sync + 'static> LockedMockWorker<T> {
 impl<T: PartialEq + Debug + Send + Sync + 'static> Worker<T> for MockWorker<T> {
     fn send(&self, req: T) -> () {
         let mut reqs = self.reqs.lock().unwrap();
-        assert!(reqs.len() > 0, format!("Unexpected request to worker {}", self.name));
+        assert!(reqs.len() > 0, "Unexpected request to worker {}", self.name);
         let next_req = reqs.remove(0);
         assert_eq!(next_req, req);
     }


### PR DESCRIPTION
Fixes warnings like these when running `cargo test`:

```
warning: panic message is not a string literal
   --> src/repo_version.rs:309:63
    |
309 |         assert!(err.contains("Error running version script"), err);
    |                                                               ^^^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
309 |         assert!(err.contains("Error running version script"), "{}", err);
    |                                                               ^^^^^

warning: panic message is not a string literal
   --> tests/mocks/mock_jira.rs:122:34
    |
122 |         assert!(calls.len() > 0, format!("Unexpected call to get_issue {}", key));
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
