### PR TITLE
Isolate tests from local environment.

### DIFF
--- a/src/repo_version.rs
+++ b/src/repo_version.rs
@@ -339,7 +339,7 @@ mod tests {
         let script_file = sub_dir.join("version.py");
         {
             let mut file = fs::File::create(&script_file).expect("create file");
-            file.write_all(b"print '1.2.3.4'").expect("write file");
+            file.write_all(b"print('1.2.3.4')").expect("write file");
         }
 
         assert_eq!("1.2.3.4", run_script("python version.py", &sub_dir).unwrap());

--- a/tests/git_helper/temp_git.rs
+++ b/tests/git_helper/temp_git.rs
@@ -16,6 +16,10 @@ pub struct TempGit {
 
 impl TempGit {
     pub fn new() -> TempGit {
+        let home = TempDir::new("home").expect("create fake home dir for configs").into_path();
+        std::env::set_var("HOME", &home);
+        std::env::set_var("XDG_CONFIG_HOME", &home);
+
         let dir = TempDir::new("git_test.rs").expect("create temp dir for git_test.rs");
 
         let repo_dir = dir.path().join("repo");


### PR DESCRIPTION
This adjusts tests to avoid global/user gitconfig and not make assumptions that python refers to python2.