### PR TITLE
Add optional login_suffix config for JIRA.

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -450,6 +450,9 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
       if (!jiraBase && resp.data.jira_base) {
         jiraBase = resp.data.jira_base;
       }
+      if (resp.data.login_suffix) {
+        $scope.req.admin_user = loggedInUser() + resp.data.login_suffix;
+      }
       return resp;
     }).finally(function(e) {
       $scope.processing = false;

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,8 @@ pub struct JiraConfig {
     pub pending_versions_field: Option<String>,
     // optional name of role to restrict octobot comment visibility. (e.g. "Developers")
     pub restrict_comment_visibility_to_role: Option<String>,
+    // optional suffix to add to the username for the login dialog (e.g. "@company.com")
+    pub login_suffix: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/server/admin.rs
+++ b/src/server/admin.rs
@@ -227,6 +227,7 @@ struct MergeVersionsReq {
 #[derive(Serialize, Clone)]
 struct MergeVersionsResp {
     jira_base: String,
+    login_suffix: Option<String>,
     versions: HashMap<String, Vec<version::Version>>,
 }
 
@@ -281,6 +282,7 @@ impl Handler for MergeVersions {
 
             let resp = MergeVersionsResp {
                 jira_base: jira_config.base_url(),
+                login_suffix: jira_config.login_suffix,
                 versions: all_relevant_versions,
             };
 

--- a/tests/github_handler_test.rs
+++ b/tests/github_handler_test.rs
@@ -160,6 +160,7 @@ fn new_test_with_jira() -> GithubHandlerTest {
         fix_versions_field: Some("the-versions".into()),
         pending_versions_field: Some("the-pending-versions".into()),
         restrict_comment_visibility_to_role: None,
+        login_suffix: None,
     });
     let mut test = new_test_with(jira);
 

--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -28,6 +28,7 @@ fn new_test() -> JiraWorkflowTest {
         fix_versions_field: Some("the-versions".into()),
         pending_versions_field: Some("the-pending-versions".into()),
         restrict_comment_visibility_to_role: None,
+        login_suffix: None,
     };
 
     JiraWorkflowTest {


### PR DESCRIPTION
If a `login_suffix` field is provided in the JIRA config, it will be
appended to the logged-in username to pre-fill the username field in the
JIRA auth dialog.

For example, if for every octobot user "$user", the corresponding JIRA
username is "$user@company.com", setting `jira.login_suffix = "@company.com"`
will mean users don't have to remember to adjust their username in the login
prompt every time they do a pending version merge.
