### PR TITLE
reorder Jira projects on add repos menu

### DIFF
--- a/src/assets/app.js
+++ b/src/assets/app.js
@@ -351,8 +351,7 @@ app.controller('ReposController', function($rootScope, $scope, sessionHttp, noti
   }
 
   $scope.addJIRA = function(theRepo) {
-    theRepo.jira_config.push({
-    });
+    theRepo.jira_config.splice(0, 0, {});
   };
 
   $scope.removeJIRA = function(theRepo, index) {


### PR DESCRIPTION
When adding a new Jira project to a repo, prepend it to the top of the
list to prevent having to scroll down to see new project.

Closes #270