### PR TITLE
Don't transition tickets with "See" keyword.

### DIFF
--- a/tests/jira_workflow_test.rs
+++ b/tests/jira_workflow_test.rs
@@ -211,7 +211,7 @@ fn test_transition_issues_only_if_necessary() {
     let pr = new_pr();
     let projects = vec!["SER".to_string(), "CLI".to_string()];
     let commit = new_commit(
-        "Fix [SER-1][SER-2][SER-3] I fixed it. And also relates to [CLI-9999][CLI-9998][OTHER-999]",
+        "Fix [SER-1][SER-2][SER-3] I fixed it. And also relates to [CLI-9999][CLI-9998][OTHER-999]. See [CLI-1]",
         "aabbccddee",
     );
 
@@ -228,6 +228,12 @@ fn test_transition_issues_only_if_necessary() {
     test.jira.mock_comment_issue(
         "SER-3",
         "Review submitted for branch master: http://the-pr",
+        Ok(()),
+    );
+    // "See:" references should be mentioned but not transitioned
+    test.jira.mock_comment_issue(
+        "CLI-1",
+        "Referenced by review submitted for branch master: http://the-pr",
         Ok(()),
     );
     test.jira.mock_comment_issue(


### PR DESCRIPTION
JIRA refs in a commit message preceded by "See" or "See:" will not be
transitioned to in-progress, but will still be referenced on the JIRA
comments. This allows mentioning related tickets in a JIRA without
automatically moving them to in-progress.

Open questions:

- Should the keyword be configurable? Fix keywords are not.
- I followed the regex for Fix, but should See be more limited?
    - Only respect "See: ", not "See"?
    - Only respect at start-of-line?
