### PR TITLE
Update to use async-await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,12 +58,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
@@ -77,16 +82,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -95,10 +90,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
 
 [[package]]
 name = "byteorder"
@@ -113,15 +126,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
  "byteorder",
- "either",
  "iovec",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.70"
+name = "bytes"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cc"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cfg-if"
@@ -168,34 +186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
-dependencies = [
- "time",
- "url 1.7.2",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
-dependencies = [
- "cookie",
- "failure",
- "idna 0.1.5",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time",
- "try_from",
- "url 1.7.2",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,15 +200,6 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -237,7 +218,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
@@ -263,22 +244,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -335,18 +304,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -408,13 +365,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
-name = "futures-cpupool"
-version = "0.1.8"
+name = "futures-channel"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
- "futures",
- "num_cpus",
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -436,20 +423,21 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "h2"
-version = "0.1.26"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
 dependencies = [
- "byteorder",
- "bytes",
+ "bytes 1.1.0",
  "fnv",
- "futures",
- "http",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.5",
  "indexmap",
- "log",
  "slab",
- "string",
- "tokio-io",
+ "tokio 1.12.0",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -485,21 +473,31 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.1.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes",
- "futures",
- "http",
- "tokio-buf",
+ "bytes 1.1.0",
+ "http 0.2.5",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -507,6 +505,12 @@ name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "httpdate"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "humantime"
@@ -519,45 +523,39 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.36"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
- "bytes",
- "futures",
- "futures-cpupool",
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "h2",
- "http",
+ "http 0.2.5",
  "http-body",
  "httparse",
- "iovec",
+ "httpdate",
  "itoa",
- "log",
- "net2",
- "rustc_version",
- "time",
- "tokio",
- "tokio-buf",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
+ "pin-project-lite",
+ "socket2",
+ "tokio 1.12.0",
+ "tower-service",
+ "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
- "futures",
+ "bytes 1.1.0",
  "hyper",
  "native-tls",
- "tokio-io",
+ "tokio 1.12.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -588,7 +586,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -602,23 +600,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "jsonwebtoken"
-version = "5.0.1"
-source = "git+https://github.com/matthauck/jsonwebtoken?rev=f4c2ab6a380bb85e931a5586cc6ca9fd8dda3ace#f4c2ab6a380bb85e931a5586cc6ca9fd8dda3ace"
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
- "base64 0.9.3",
- "chrono",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
+dependencies = [
+ "base64 0.12.3",
+ "pem",
  "ring",
  "serde",
- "serde_derive",
  "serde_json",
- "untrusted",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -701,7 +714,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -711,23 +724,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -743,10 +746,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.7",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -757,7 +773,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.23",
 ]
 
 [[package]]
@@ -770,6 +786,15 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -812,12 +837,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -827,7 +872,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -853,10 +898,10 @@ dependencies = [
 name = "octobot"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "env_logger",
  "failure",
- "futures",
- "http",
+ "http 0.1.21",
  "hyper",
  "log",
  "maplit",
@@ -872,7 +917,7 @@ dependencies = [
  "tempdir",
  "thread-id",
  "time",
- "tokio",
+ "tokio 1.12.0",
  "tokio-core",
  "tokio-threadpool",
 ]
@@ -893,6 +938,7 @@ dependencies = [
 name = "octobot_lib"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.10.1",
  "conventional",
  "failure",
@@ -917,9 +963,9 @@ dependencies = [
 name = "octobot_ops"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "conventional",
  "failure",
- "futures",
  "hyper",
  "log",
  "maplit",
@@ -930,7 +976,7 @@ dependencies = [
  "serde_derive",
  "tempdir",
  "time",
- "tokio",
+ "tokio 1.12.0",
  "unidiff",
 ]
 
@@ -986,7 +1032,7 @@ version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1020,6 +1066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1087,18 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1053,16 +1122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "publicsuffix"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
-dependencies = [
- "idna 0.2.3",
- "url 2.2.2",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,9 +1129,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -1092,43 +1151,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1167,73 +1197,11 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1288,49 +1256,51 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.24"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
- "base64 0.10.1",
- "bytes",
- "cookie",
- "cookie_store",
+ "base64 0.13.0",
+ "bytes 1.1.0",
  "encoding_rs",
- "flate2",
- "futures",
- "http",
+ "futures-core",
+ "futures-util",
+ "http 0.2.5",
+ "http-body",
  "hyper",
  "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "time",
- "tokio",
- "tokio-executor",
- "tokio-io",
- "tokio-threadpool",
- "tokio-timer",
- "url 1.7.2",
- "uuid",
+ "tokio 1.12.0",
+ "tokio-native-tls",
+ "url 2.2.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "winreg",
 ]
 
 [[package]]
 name = "ring"
-version = "0.14.6"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
- "lazy_static",
  "libc",
+ "once_cell",
  "spin",
  "untrusted",
+ "web-sys",
  "winapi 0.3.9",
 ]
 
@@ -1386,12 +1356,6 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
@@ -1486,14 +1450,25 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url 1.7.2",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
@@ -1518,25 +1493,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "string"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.77"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1631,9 +1607,9 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "tokio-codec",
  "tokio-current-thread",
@@ -1650,14 +1626,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.1"
+name = "tokio"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
- "bytes",
- "either",
- "futures",
+ "autocfg",
+ "bytes 1.1.0",
+ "libc",
+ "memchr",
+ "mio 0.7.13",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1666,7 +1648,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "tokio-io",
 ]
@@ -1677,13 +1659,13 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "iovec",
  "log",
- "mio",
+ "mio 0.6.23",
  "scoped-tls",
- "tokio",
+ "tokio 0.1.22",
  "tokio-executor",
  "tokio-io",
  "tokio-reactor",
@@ -1727,9 +1709,30 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "log",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -1742,7 +1745,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "mio",
+ "mio 0.6.23",
  "num_cpus",
  "parking_lot",
  "slab",
@@ -1767,10 +1770,10 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "iovec",
- "mio",
+ "mio 0.6.23",
  "tokio-io",
  "tokio-reactor",
 ]
@@ -1810,10 +1813,10 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "log",
- "mio",
+ "mio 0.6.23",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
@@ -1825,16 +1828,30 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
- "bytes",
+ "bytes 0.4.12",
  "futures",
  "iovec",
  "libc",
  "log",
- "mio",
+ "mio 0.6.23",
  "mio-uds",
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio 1.12.0",
 ]
 
 [[package]]
@@ -1847,19 +1864,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "try_from"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
-dependencies = [
- "cfg-if 0.1.10",
-]
 
 [[package]]
 name = "unicase"
@@ -1904,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
@@ -1932,15 +1966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,11 +1979,10 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "futures",
  "log",
  "try-lock",
 ]
@@ -1968,6 +1992,84 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -2014,9 +2116,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ conventional = "0.5.0"
 failure = "0.1.5"
 log = "0.4.6"
 regex = "1.1.2"
-ring = "0.14.6"
+ring = "0.16.20"
 rusqlite = "0.25.3"
 rustc-serialize = "0.3.24"
 serde = "1.0.89"
@@ -24,13 +24,9 @@ serde_json = "1.0.39"
 time = "0.1.42"
 toml = "0.5.0"
 url = "1.7.2"
-
-[dependencies.reqwest]
-version = "0.9.12"
-
-[dependencies.jsonwebtoken]
-git = "https://github.com/matthauck/jsonwebtoken"
-rev = "f4c2ab6a380bb85e931a5586cc6ca9fd8dda3ace"
+jsonwebtoken = "7.2.0"
+reqwest = { version = "0.11.4", features = ["json"]}
+async-trait = "0.1.51"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -194,7 +194,7 @@ impl BranchRef {
     }
 }
 
-pub trait PullRequestLike {
+pub trait PullRequestLike : Send + Sync {
     fn user(&self) -> &User;
     fn assignees(&self) -> Vec<User>;
     fn title(&self) -> &str;
@@ -343,7 +343,7 @@ impl Label {
 }
 
 
-pub trait CommentLike {
+pub trait CommentLike : Send + Sync {
     fn user(&self) -> &User;
     fn body(&self) -> &str;
     fn html_url(&self) -> &str;
@@ -413,7 +413,7 @@ impl<'a> CommentLike for &'a Comment {
     }
 }
 
-pub trait CommitLike {
+pub trait CommitLike : Send + Sync {
     fn sha(&self) -> &str;
     fn html_url(&self) -> &str;
     fn message(&self) -> &str;

--- a/lib/src/jwt.rs
+++ b/lib/src/jwt.rs
@@ -1,6 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use jsonwebtoken::{self, Algorithm, Header};
+use jsonwebtoken::{self, Algorithm, Header, EncodingKey};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,5 +18,7 @@ pub fn new_token(app_id: u32, app_key_der: &[u8]) -> String {
         iss: app_id.to_string(),
     };
 
-    return jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, app_key_der).unwrap();
+    let key = EncodingKey::from_rsa_der(app_key_der);
+
+    return jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, &key).unwrap();
 }

--- a/lib/src/passwd.rs
+++ b/lib/src/passwd.rs
@@ -2,7 +2,7 @@ use ring::{digest, pbkdf2};
 use log::error;
 use rustc_serialize::hex::{FromHex, ToHex};
 
-static DIGEST_ALG: &'static digest::Algorithm = &digest::SHA256;
+static DIGEST_ALG: &'static pbkdf2::Algorithm = &pbkdf2::PBKDF2_HMAC_SHA256;
 const CREDENTIAL_LEN: usize = digest::SHA256_OUTPUT_LEN;
 
 fn pbdkf2_iterations() -> std::num::NonZeroU32 {
@@ -12,7 +12,7 @@ fn pbdkf2_iterations() -> std::num::NonZeroU32 {
 pub fn store_password(pass: &str, salt: &str) -> String {
     let mut pass_hash = [0u8; CREDENTIAL_LEN];
     pbkdf2::derive(
-        DIGEST_ALG,
+        *DIGEST_ALG,
         pbdkf2_iterations(),
         salt.as_bytes(),
         pass.as_bytes(),
@@ -32,7 +32,7 @@ pub fn verify_password(pass: &str, salt: &str, pass_hash: &str) -> bool {
         }
     };
     pbkdf2::verify(
-        DIGEST_ALG,
+        *DIGEST_ALG,
         pbdkf2_iterations(),
         salt.as_bytes(),
         pass.as_bytes(),

--- a/octobot/Cargo.toml
+++ b/octobot/Cargo.toml
@@ -20,21 +20,21 @@ octobot_ldap = { "path" = "../ldap" }
 octobot_ops = { "path" = "../ops" }
 env_logger = "0.6.1"
 failure = "0.1.5"
-futures = "0.1.25"
 http = "0.1.16"
-hyper = "0.12.25"
+hyper = { version = "0.14.13", features = ["server"]}
 log = "0.4.6"
 regex = "1.1.2"
-ring = "0.14.6"
+ring = "0.16.20"
 rustc-serialize = "0.3.24"
 serde = "1.0.89"
 serde_derive = "1.0.89"
 serde_json = "1.0.39"
 thread-id = "3.3.0"
 time = "0.1.42"
-tokio = "0.1.17"
+tokio = { version = "1.12.0", features = ["rt", "rt-multi-thread", "macros"]}
 tokio-core = "0.1.17"
 tokio-threadpool = "0.1.12"
+async-trait = "0.1.51"
 
 [dev-dependencies]
 maplit = "1.0.1"

--- a/octobot/src/http_util.rs
+++ b/octobot/src/http_util.rs
@@ -33,5 +33,3 @@ pub fn new_error_resp<S: Into<String>>(msg: S) -> Response<Body> {
 pub fn new_bad_req_resp<S: Into<String>>(msg: S) -> Response<Body> {
     new_msg_resp(StatusCode::BAD_REQUEST, msg)
 }
-
-

--- a/octobot/src/server/admin.rs
+++ b/octobot/src/server/admin.rs
@@ -38,8 +38,8 @@ pub struct RepoAdmin {
 
 
 impl UserAdmin {
-    pub fn new(config: Arc<Config>, op: Op) -> Arc<UserAdmin> {
-        Arc::new(UserAdmin {
+    pub fn new(config: Arc<Config>, op: Op) -> Box<UserAdmin> {
+        Box::new(UserAdmin {
             config: config,
             op: op,
         })
@@ -47,8 +47,8 @@ impl UserAdmin {
 }
 
 impl RepoAdmin {
-    pub fn new(config: Arc<Config>, op: Op) -> Arc<RepoAdmin> {
-        Arc::new(RepoAdmin {
+    pub fn new(config: Arc<Config>, op: Op) -> Box<RepoAdmin> {
+        Box::new(RepoAdmin {
             config: config,
             op: op,
         })
@@ -194,8 +194,8 @@ pub struct MergeVersions {
 }
 
 impl MergeVersions {
-    pub fn new(config: Arc<Config>) -> Arc<MergeVersions> {
-        Arc::new(MergeVersions { config: config })
+    pub fn new(config: Arc<Config>) -> Box<MergeVersions> {
+        Box::new(MergeVersions { config: config })
     }
 }
 

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -108,13 +108,13 @@ impl GithubHandler {
         config: Arc<Config>,
         github_app: Arc<dyn github::api::GithubSessionFactory>,
         jira_session: Option<Arc<dyn jira::api::Session>>,
-    ) -> Arc<GithubHandler> {
+    ) -> Box<GithubHandler> {
         let state = GithubHandlerState::new(config, github_app, jira_session);
         GithubHandler::from_state(Arc::new(state))
     }
 
-    pub fn from_state(state: Arc<GithubHandlerState>) -> Arc<GithubHandler> {
-        Arc::new(GithubHandler { state: state })
+    pub fn from_state(state: Arc<GithubHandlerState>) -> Box<GithubHandler> {
+        Box::new(GithubHandler { state: state })
     }
 }
 

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -1,14 +1,13 @@
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 
-use futures::Future;
-use futures::Stream;
-use hyper::{Body, Request, StatusCode};
+use hyper::{Body, Request, Response, StatusCode};
 use log::{info, error};
 use regex::Regex;
 use serde_json;
 use tokio;
 
+use octobot_lib::errors::Result;
 use octobot_lib::config::Config;
 use octobot_lib::github::api::Session;
 use octobot_lib::github::CommentLike;
@@ -26,7 +25,7 @@ use octobot_ops::worker::{Worker, TokioWorker};
 use crate::http_util;
 use crate::runtime;
 use crate::server::github_verify::GithubWebhookVerifier;
-use crate::server::http::{FutureResponse, Handler};
+use crate::server::http::Handler;
 
 pub struct GithubHandlerState {
     pub config: Arc<Config>,
@@ -109,25 +108,30 @@ impl GithubHandler {
         config: Arc<Config>,
         github_app: Arc<dyn github::api::GithubSessionFactory>,
         jira_session: Option<Arc<dyn jira::api::Session>>,
-    ) -> Box<GithubHandler> {
+    ) -> Arc<GithubHandler> {
         let state = GithubHandlerState::new(config, github_app, jira_session);
         GithubHandler::from_state(Arc::new(state))
     }
 
-    pub fn from_state(state: Arc<GithubHandlerState>) -> Box<GithubHandler> {
-        Box::new(GithubHandler { state: state })
+    pub fn from_state(state: Arc<GithubHandlerState>) -> Arc<GithubHandler> {
+        Arc::new(GithubHandler { state: state })
     }
 }
 
+#[async_trait::async_trait]
 impl Handler for GithubHandler {
-    fn handle(&self, req: Request<Body>) -> FutureResponse {
+    async fn handle(&self, req: Request<Body>) -> Result<Response<Body>> {
+        Ok(self.handle_ok(req).await)
+    }
+
+    async fn handle_ok(&self, req: Request<Body>) -> Response<Body> {
         let event_id;
         {
             let values = req.headers().get_all("x-github-delivery").iter().collect::<Vec<_>>();
             if values.len() != 1 {
                 let msg = "Expected to find exactly one event id header";
                 error!("{}", msg);
-                return self.respond(http_util::new_bad_req_resp(msg));
+                return http_util::new_bad_req_resp(msg);
             }
 
             event_id = String::from_utf8_lossy(values[0].as_bytes()).into_owned();
@@ -139,7 +143,7 @@ impl Handler for GithubHandler {
             if !util::check_unique_event(event_id.clone(), &mut *recent_events, 1000, 100) {
                 let msg = format!("Duplicate X-Github-Delivery header: {}", event_id);
                 error!("{}", msg);
-                return self.respond(http_util::new_bad_req_resp(msg));
+                return http_util::new_bad_req_resp(msg);
             }
         }
 
@@ -149,7 +153,7 @@ impl Handler for GithubHandler {
             if values.len() != 1 {
                 let msg = "Expected to find exactly one event header";
                 error!("{}", msg);
-                return self.respond(http_util::new_bad_req_resp(msg));
+                return http_util::new_bad_req_resp(msg);
             }
             event = String::from_utf8_lossy(values[0].as_bytes()).into_owned();
         }
@@ -163,115 +167,121 @@ impl Handler for GithubHandler {
         let force_push = self.state.force_push_worker.clone();
         let slack = self.state.slack_worker.clone();
 
-        Box::new(req.into_body().concat2().map(move |body| {
-            let verifier = GithubWebhookVerifier { secret: config.github.webhook_secret.clone() };
-            if !verifier.is_req_valid(&headers, &body) {
-                return http_util::new_msg_resp(StatusCode::FORBIDDEN, "Invalid signature");
+        let body = match hyper::body::to_bytes(req.into_body()).await {
+            Ok(b) => b,
+            Err(e) => {
+                error!("Error reading request body: {}", e);
+                return http_util::new_bad_req_resp(format!("Error reading request body: {}", e));
             }
+        };
 
-            let mut data: github::HookBody = match serde_json::from_slice(&body) {
-                Ok(h) => h,
-                Err(e) => {
-                    error!("Error parsing json: {}\n---\n{}\n---\n", e, String::from_utf8_lossy(&body));
-                    return http_util::new_bad_req_resp(format!("Error parsing JSON: {}", e));
-                }
-            };
+        let verifier = GithubWebhookVerifier { secret: config.github.webhook_secret.clone() };
+        if !verifier.is_req_valid(&headers, &body) {
+            return http_util::new_msg_resp(StatusCode::FORBIDDEN, "Invalid signature");
+        }
 
-            let github_session = match github_app.new_session(&data.repository.owner.login(), &data.repository.name) {
-                // Note: this doesn't really need to be an Arc anymore...
-                Ok(g) => Arc::new(g),
-                Err(e) => {
-                    error!(
-                        "Error creating a new github session for {}/{}: {}",
-                        data.repository.owner.login(),
-                        &data.repository.name,
-                        e
-                    );
-                    return http_util::new_bad_req_resp("Could not create github session");
-                }
-            };
-
-            let action = match data.action {
-                Some(ref a) => a.clone(),
-                None => String::new(),
-            };
-
-            // Try to remap issues which are PRs as pull requests. This gives us access to PR information
-            // like reviewers which do not exist for issues.
-            if let Some(ref issue) = data.issue {
-                if data.pull_request.is_none() && issue.html_url.contains("/pull/") {
-                    data.pull_request = match github_session.get_pull_request(
-                        &data.repository.owner.login(),
-                        &data.repository.name,
-                        issue.number,
-                    ) {
-                        Ok(pr) => Some(pr),
-                        Err(e) => {
-                            error!("Error refetching issue #{} as pull request: {}", issue.number, e);
-                            None
-                        }
-                    };
-                }
+        let mut data: github::HookBody = match serde_json::from_slice(&body) {
+            Ok(h) => h,
+            Err(e) => {
+                error!("Error parsing json: {}\n---\n{}\n---\n", e, String::from_utf8_lossy(&body));
+                return http_util::new_bad_req_resp(format!("Error parsing JSON: {}", e));
             }
+        };
 
-            // refetch PR if present to get requested reviewers: they don't come on each webhook :cry:
-            let mut changed_pr = None;
-            if let Some(ref pull_request) = data.pull_request {
-                if pull_request.requested_reviewers.is_none() || pull_request.reviews.is_none() {
-                    match github_session.get_pull_request(
-                        &data.repository.owner.login(),
-                        &data.repository.name,
-                        pull_request.number,
-                    ) {
-                        Ok(pr) => changed_pr = Some(pr),
-                        Err(e) => error!("Error refetching pull request to get reviewers: {}", e),
-                    };
-                }
+        let github_session = match github_app.new_session(&data.repository.owner.login(), &data.repository.name).await {
+            // Note: this doesn't really need to be an Arc anymore...
+            Ok(g) => Arc::new(g),
+            Err(e) => {
+                error!(
+                    "Error creating a new github session for {}/{}: {}",
+                    data.repository.owner.login(),
+                    &data.repository.name,
+                    e
+                );
+                return http_util::new_bad_req_resp("Could not create github session");
             }
-            if let Some(changed_pr) = changed_pr {
-                data.pull_request = Some(changed_pr);
-            }
+        };
 
-            let handler = GithubEventHandler {
-                event: event.clone(),
-                data: data,
-                action: action,
-                config: config.clone(),
-                messenger: messenger::new(config.clone(), slack),
-                github_session: github_session,
-                jira_session: jira_session,
-                pr_merge: pr_merge,
-                repo_version: repo_version,
-                force_push: force_push,
-            };
+        let action = match data.action {
+            Some(ref a) => a.clone(),
+            None => String::new(),
+        };
 
-            match handler.handle_event() {
-                Some((status, resp)) => http_util::new_msg_resp(status, resp),
-                None => http_util::new_msg_resp(StatusCode::OK, format!("Unhandled event: {}", event)),
+        // Try to remap issues which are PRs as pull requests. This gives us access to PR information
+        // like reviewers which do not exist for issues.
+        if let Some(ref issue) = data.issue {
+            if data.pull_request.is_none() && issue.html_url.contains("/pull/") {
+                data.pull_request = match github_session.get_pull_request(
+                    &data.repository.owner.login(),
+                    &data.repository.name,
+                    issue.number,
+                ).await {
+                    Ok(pr) => Some(pr),
+                    Err(e) => {
+                        error!("Error refetching issue #{} as pull request: {}", issue.number, e);
+                        None
+                    }
+                };
             }
-        }))
+        }
+
+        // refetch PR if present to get requested reviewers: they don't come on each webhook :cry:
+        let mut changed_pr = None;
+        if let Some(ref pull_request) = data.pull_request {
+            if pull_request.requested_reviewers.is_none() || pull_request.reviews.is_none() {
+                match github_session.get_pull_request(
+                    &data.repository.owner.login(),
+                    &data.repository.name,
+                    pull_request.number,
+                ).await {
+                    Ok(pr) => changed_pr = Some(pr),
+                    Err(e) => error!("Error refetching pull request to get reviewers: {}", e),
+                };
+            }
+        }
+        if let Some(changed_pr) = changed_pr {
+            data.pull_request = Some(changed_pr);
+        }
+
+        let handler = GithubEventHandler {
+            event: event.clone(),
+            data: data,
+            action: action,
+            config: config.clone(),
+            messenger: messenger::new(config.clone(), slack),
+            github_session: github_session,
+            jira_session: jira_session,
+            pr_merge: pr_merge,
+            repo_version: repo_version,
+            force_push: force_push,
+        };
+
+        match handler.handle_event().await {
+            Some((status, resp)) => http_util::new_msg_resp(status, resp),
+            None => http_util::new_msg_resp(StatusCode::OK, format!("Unhandled event: {}", event)),
+        }
     }
 }
 
 type EventResponse = (StatusCode, String);
 
 impl GithubEventHandler {
-    pub fn handle_event(&self) -> Option<EventResponse> {
+    pub async fn handle_event(&self) -> Option<EventResponse> {
         info!("Received event: {}", self.event);
         if self.event == "ping" {
             Some(self.handle_ping())
         } else if self.event == "pull_request" {
-            Some(self.handle_pr())
+            Some(self.handle_pr().await)
         } else if self.event == "pull_request_review_comment" {
-            Some(self.handle_pr_review_comment())
+            Some(self.handle_pr_review_comment().await)
         } else if self.event == "pull_request_review" {
-            Some(self.handle_pr_review())
+            Some(self.handle_pr_review().await)
         } else if self.event == "commit_comment" {
-            Some(self.handle_commit_comment())
+            Some(self.handle_commit_comment().await)
         } else if self.event == "issue_comment" {
-            Some(self.handle_issue_comment())
+            Some(self.handle_issue_comment().await)
         } else if self.event == "push" {
-            Some(self.handle_push())
+            Some(self.handle_push().await)
         } else {
             None
         }
@@ -290,7 +300,7 @@ impl GithubEventHandler {
         users.iter().map(|u| self.slack_user_name(u)).collect()
     }
 
-    fn pull_request_commits(&self, pull_request: &dyn github::PullRequestLike) -> Vec<github::Commit> {
+    async fn pull_request_commits(&self, pull_request: &dyn github::PullRequestLike) -> Vec<github::Commit> {
         if !pull_request.has_commits() {
             return vec![];
         }
@@ -299,7 +309,7 @@ impl GithubEventHandler {
             &self.data.repository.owner.login(),
             &self.data.repository.name,
             pull_request.number(),
-        ) {
+        ).await {
             Ok(commits) => commits,
             Err(e) => {
                 error!("Error looking up PR commits: {}", e);
@@ -333,7 +343,7 @@ impl GithubEventHandler {
         (StatusCode::OK, "ping".into())
     }
 
-    fn handle_pr(&self) -> EventResponse {
+    async fn handle_pr(&self) -> EventResponse {
         enum NotifyMode {
             NotifyAll,
             NotifyChannel,
@@ -387,7 +397,7 @@ impl GithubEventHandler {
                 return (StatusCode::OK, "pr".into())
             }
 
-            let commits = self.pull_request_commits(&pull_request);
+            let commits = self.pull_request_commits(&pull_request).await;
 
             if let Some(ref verb) = verb {
                 let branch_name = &pull_request.base.ref_name;
@@ -451,7 +461,7 @@ impl GithubEventHandler {
                                     &jira_projects,
                                     jira_session.deref(),
                                     jira_config,
-                                );
+                                ).await;
                             }
                         }
                     }
@@ -466,7 +476,7 @@ impl GithubEventHandler {
                         &commits,
                         &jira_projects,
                         self.github_session.deref(),
-                    );
+                    ).await;
                 }
             }
 
@@ -476,22 +486,22 @@ impl GithubEventHandler {
                     self.merge_pull_request(pull_request, label, &release_branch_prefix, &commits);
                 }
             } else if verb == Some("merged".to_string()) {
-                self.merge_pull_request_all_labels(pull_request, &release_branch_prefix, &commits);
+                self.merge_pull_request_all_labels(pull_request, &release_branch_prefix, &commits).await;
             }
         }
 
         (StatusCode::OK, "pr".into())
     }
 
-    fn handle_pr_review_comment(&self) -> EventResponse {
+    async fn handle_pr_review_comment(&self) -> EventResponse {
         if let Some(ref pull_request) = self.data.pull_request {
             if let Some(ref comment) = self.data.comment {
                 if self.action == "created" {
 
                     let branch_name = &pull_request.base.ref_name;
-                    let commits = self.pull_request_commits(&pull_request);
+                    let commits = self.pull_request_commits(&pull_request).await;
 
-                    self.do_pull_request_comment(&pull_request, &comment, branch_name, &commits)
+                    self.do_pull_request_comment(&pull_request, &comment, branch_name, &commits);
                 }
 
             }
@@ -500,13 +510,13 @@ impl GithubEventHandler {
         (StatusCode::OK, "pr_review_comment".into())
     }
 
-    fn handle_pr_review(&self) -> EventResponse {
+    async fn handle_pr_review(&self) -> EventResponse {
         if let Some(ref pull_request) = self.data.pull_request {
             if let Some(ref review) = self.data.review {
                 if self.action == "submitted" {
 
                     let branch_name = &pull_request.base.ref_name;
-                    let commits = self.pull_request_commits(&pull_request);
+                    let commits = self.pull_request_commits(&pull_request).await;
 
                     // just a comment. should just be handled by regular comment handler.
                     if review.state == "commented" {
@@ -602,10 +612,9 @@ impl GithubEventHandler {
             &branch_name,
             &commits,
         );
-
     }
 
-    fn handle_commit_comment(&self) -> EventResponse {
+    async fn handle_commit_comment(&self) -> EventResponse {
         if let Some(ref comment) = self.data.comment {
             if self.action == "created" {
                 if let Some(ref commit_id) = comment.commit_id {
@@ -649,13 +658,13 @@ impl GithubEventHandler {
         (StatusCode::OK, "commit_comment".into())
     }
 
-    fn handle_issue_comment(&self) -> EventResponse {
+    async fn handle_issue_comment(&self) -> EventResponse {
         if let Some(ref comment) = self.data.comment {
             if self.action == "created" {
                 // Check to see if we remapped this "issue" to a PR
                 if let Some(ref pr) = self.data.pull_request {
                     let branch_name = &pr.base.ref_name;
-                    let commits = self.pull_request_commits(&pr);
+                    let commits = self.pull_request_commits(&pr).await;
 
                     self.do_pull_request_comment(&pr, &comment, branch_name, &commits);
                 } else if let Some(ref issue) = self.data.issue {
@@ -671,11 +680,12 @@ impl GithubEventHandler {
         (StatusCode::OK, "issue_comment".into())
     }
 
-    fn handle_push(&self) -> EventResponse {
+    async fn handle_push(&self) -> EventResponse {
         if self.data.deleted() || self.data.created() {
             // ignore
             return (StatusCode::OK, "push [ignored]".into());
         }
+
         if self.data.ref_name().len() > 0 && self.data.after().len() > 0 && self.data.before().len() > 0 {
 
             let branch_name = self.data.ref_name().replace("refs/heads/", "");
@@ -690,7 +700,7 @@ impl GithubEventHandler {
                     &self.data.repository.name,
                     Some("open"),
                     None,
-                ) {
+                ).await {
                     Ok(p) => p,
                     Err(e) => {
                         error!("Error looking up PR for '{}' ({}): {}", branch_name, self.data.after(), e);
@@ -749,7 +759,7 @@ impl GithubEventHandler {
                                     .build(),
                             );
 
-                        let commits = self.pull_request_commits(&pull_request);
+                        let commits = self.pull_request_commits(&pull_request).await;
 
                         self.messenger.send_to_all(
                             &message,
@@ -781,7 +791,7 @@ impl GithubEventHandler {
                             &commits,
                             &jira_projects,
                             self.github_session.deref(),
-                        );
+                        ).await;
                     }
                 }
             }
@@ -806,7 +816,7 @@ impl GithubEventHandler {
         (StatusCode::OK, "push".into())
     }
 
-    fn merge_pull_request_all_labels(&self, pull_request: &github::PullRequest, release_branch_prefix: &str, commits: &Vec<github::Commit>) {
+    async fn merge_pull_request_all_labels(&self, pull_request: &github::PullRequest, release_branch_prefix: &str, commits: &Vec<github::Commit>) {
         if !pull_request.is_merged() {
             return;
         }
@@ -817,7 +827,7 @@ impl GithubEventHandler {
             &self.data.repository.owner.login(),
             &self.data.repository.name,
             pull_request.number,
-        ) {
+        ).await {
             Ok(l) => l,
             Err(e) => {
                 self.messenger.send_to_owner(

--- a/octobot/src/server/github_verify.rs
+++ b/octobot/src/server/github_verify.rs
@@ -1,6 +1,6 @@
 use hyper::HeaderMap;
 use log::{debug, error};
-use ring::{digest, hmac};
+use ring::hmac;
 use rustc_serialize::hex::FromHex;
 
 pub struct GithubWebhookVerifier {
@@ -40,7 +40,7 @@ impl GithubWebhookVerifier {
             }
         };
 
-        let key = hmac::VerificationKey::new(&digest::SHA1, self.secret.as_bytes());
+        let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, self.secret.as_bytes());
         match hmac::verify(&key, data, &sig_bytes) {
             Ok(_) => {
                 debug!("Signature verified!");
@@ -57,13 +57,13 @@ impl GithubWebhookVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ring::{digest, hmac};
+    use ring::hmac;
     use rustc_serialize::hex::ToHex;
 
     #[test]
     fn verify_sig_valid() {
         let key_value = String::from("this is my secret key!");
-        let key = hmac::SigningKey::new(&digest::SHA1, key_value.as_bytes());
+        let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key_value.as_bytes());
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn verify_sig_wrong_digest() {
         let key_value = String::from("this is my secret key!");
-        let key = hmac::SigningKey::new(&digest::SHA1, key_value.as_bytes());
+        let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key_value.as_bytes());
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn verify_sig_missing_header() {
         let key_value = String::from("this is my secret key!");
-        let key = hmac::SigningKey::new(&digest::SHA1, key_value.as_bytes());
+        let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key_value.as_bytes());
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());

--- a/octobot/src/server/html_handler.rs
+++ b/octobot/src/server/html_handler.rs
@@ -1,11 +1,13 @@
 use std::env;
 use std::fs::File;
 use std::io::Read;
+use std::sync::Arc;
 
 use hyper::{Body, Request, Response};
 use hyper::header::CONTENT_TYPE;
 
-use crate::server::http::{FutureResponse, Handler};
+use octobot_lib::errors::Result;
+use crate::server::http::Handler;
 
 fn is_dev_mode() -> bool {
     env::var("DEVMODE").is_ok()
@@ -17,8 +19,8 @@ pub struct HtmlHandler {
 }
 
 impl HtmlHandler {
-    pub fn new(path: &str, contents: &str) -> Box<HtmlHandler> {
-        Box::new(HtmlHandler {
+    pub fn new(path: &str, contents: &str) -> Arc<HtmlHandler> {
+        Arc::new(HtmlHandler {
             path: path.into(),
             contents: contents.into(),
         })
@@ -42,11 +44,12 @@ impl HtmlHandler {
     }
 }
 
+#[async_trait::async_trait]
 impl Handler for HtmlHandler {
-    fn handle(&self, _: Request<Body>) -> FutureResponse {
+    async fn handle(&self, _: Request<Body>) -> Result<Response<Body>> {
         let mut resp = Response::new(Body::from(self.contents()));
         resp.headers_mut().insert(CONTENT_TYPE, "text/html".parse().unwrap());
 
-        self.respond(resp)
+        Ok(resp)
     }
 }

--- a/octobot/src/server/html_handler.rs
+++ b/octobot/src/server/html_handler.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs::File;
 use std::io::Read;
-use std::sync::Arc;
 
 use hyper::{Body, Request, Response};
 use hyper::header::CONTENT_TYPE;
@@ -19,8 +18,8 @@ pub struct HtmlHandler {
 }
 
 impl HtmlHandler {
-    pub fn new(path: &str, contents: &str) -> Arc<HtmlHandler> {
-        Arc::new(HtmlHandler {
+    pub fn new(path: &str, contents: &str) -> Box<HtmlHandler> {
+        Box::new(HtmlHandler {
             path: path.into(),
             contents: contents.into(),
         })

--- a/octobot/src/server/http.rs
+++ b/octobot/src/server/http.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use hyper::{self, Body, Request, Response, StatusCode};
 use log::error;
@@ -43,15 +41,15 @@ pub enum FilterResult {
 }
 
 pub struct FilteredHandler {
-    filter: Arc<dyn Filter>,
-    handler: Arc<dyn Handler>,
+    filter: Box<dyn Filter>,
+    handler: Box<dyn Handler>,
 }
 
 pub struct NotFoundHandler;
 
 impl FilteredHandler {
-    pub fn new(filter: Arc<dyn Filter>, handler: Arc<dyn Handler>) -> Arc<FilteredHandler> {
-        Arc::new(FilteredHandler {
+    pub fn new(filter: Box<dyn Filter>, handler: Box<dyn Handler>) -> Box<FilteredHandler> {
+        Box::new(FilteredHandler {
             filter,
             handler,
         })

--- a/octobot/src/server/login.rs
+++ b/octobot/src/server/login.rs
@@ -32,8 +32,8 @@ pub struct LoginSessionFilter {
 }
 
 impl LoginHandler {
-    pub fn new(sessions: Arc<Sessions>, config: Arc<Config>) -> Arc<LoginHandler> {
-        Arc::new(LoginHandler {
+    pub fn new(sessions: Arc<Sessions>, config: Arc<Config>) -> Box<LoginHandler> {
+        Box::new(LoginHandler {
             sessions: sessions,
             config: config,
         })
@@ -41,20 +41,20 @@ impl LoginHandler {
 }
 
 impl LogoutHandler {
-    pub fn new(sessions: Arc<Sessions>) -> Arc<LogoutHandler> {
-        Arc::new(LogoutHandler { sessions: sessions })
+    pub fn new(sessions: Arc<Sessions>) -> Box<LogoutHandler> {
+        Box::new(LogoutHandler { sessions: sessions })
     }
 }
 
 impl SessionCheckHandler {
-    pub fn new(sessions: Arc<Sessions>) -> Arc<SessionCheckHandler> {
-        Arc::new(SessionCheckHandler { sessions: sessions })
+    pub fn new(sessions: Arc<Sessions>) -> Box<SessionCheckHandler> {
+        Box::new(SessionCheckHandler { sessions: sessions })
     }
 }
 
 impl LoginSessionFilter {
-    pub fn new(sessions: Arc<Sessions>) -> Arc<LoginSessionFilter> {
-        Arc::new(LoginSessionFilter { sessions: sessions })
+    pub fn new(sessions: Arc<Sessions>) -> Box<LoginSessionFilter> {
+        Box::new(LoginSessionFilter { sessions: sessions })
     }
 }
 

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -1,11 +1,9 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use futures::Future;
 use log::{error, info};
 use hyper::server::Server;
 use hyper::service::{make_service_fn, service_fn};
-use tokio;
 
 use octobot_lib::config::Config;
 use octobot_lib::github;
@@ -19,10 +17,12 @@ use crate::server::sessions::Sessions;
 pub fn start(config: Config) {
     let num_http_threads = config.main.num_http_threads.unwrap_or(20);
 
-    runtime::run(num_http_threads, move || run_server(config));
+    runtime::run(num_http_threads, async move {
+        run_server(config).await
+    });
 }
 
-fn run_server(config: Config) {
+async fn run_server(config: Config) {
     let config = Arc::new(config);
 
     let github: Arc<dyn github::api::GithubSessionFactory>;
@@ -32,7 +32,7 @@ fn run_server(config: Config) {
             &config.github.host,
             config.github.app_id.expect("expected an app_id"),
             &config.github.app_key().expect("expected an app_key"),
-        ) {
+        ).await {
             Ok(s) => Arc::new(s),
             Err(e) => panic!("Error initiating github session: {}", e),
         };
@@ -40,7 +40,7 @@ fn run_server(config: Config) {
         github = match github::api::GithubOauthApp::new(
             &config.github.host,
             &config.github.api_token.as_ref().expect("expected an api_token"),
-        ) {
+        ).await {
             Ok(s) => Arc::new(s),
             Err(e) => panic!("Error initiating github session: {}", e),
         };
@@ -48,7 +48,7 @@ fn run_server(config: Config) {
 
     let jira: Option<Arc<dyn jira::api::Session>>;
     if let Some(ref jira_config) = config.jira {
-        jira = match JiraSession::new(&jira_config) {
+        jira = match JiraSession::new(&jira_config).await {
             Ok(s) => Some(Arc::new(s)),
             Err(e) => panic!("Error initiating jira session: {}", e),
         };
@@ -67,14 +67,19 @@ fn run_server(config: Config) {
 
     let main_service = make_service_fn(move |_| {
         let octobot = octobot.clone();
-        service_fn(move |req: hyper::Request<hyper::Body>| {
-            octobot.call(req)
-        })
+        async move {
+            let octobot = octobot.clone();
+            Ok::<_, hyper::Error>(service_fn(move |req| {
+                let octobot = octobot.clone();
+                octobot.call(req)
+            }))
+        }
     });
 
-    let server = Server::bind(&http_addr).serve(main_service).map(|_| ()).map_err(
-        |e| error!("server error: {}", e),
-    );
+    let server = Server::bind(&http_addr).serve(main_service);
     info!("Listening (HTTP) on {}", http_addr);
-    tokio::spawn(server);
+
+    if let Err(e) = server.await {
+        error!("server error: {}", e);
+    }
 }

--- a/octobot/src/server/octobot_service.rs
+++ b/octobot/src/server/octobot_service.rs
@@ -49,7 +49,7 @@ impl OctobotService {
         Ok(res)
     }
 
-    fn route(&self, req: &Request<Body>) -> Arc<dyn Handler> {
+    fn route(&self, req: &Request<Body>) -> Box<dyn Handler> {
         // API routes
         if req.uri().path().starts_with("/api") {
             let filter = LoginSessionFilter::new(self.ui_sessions.clone());
@@ -69,7 +69,7 @@ impl OctobotService {
 
                     (&Method::POST, "/api/merge-versions") => admin::MergeVersions::new(self.config.clone()),
 
-                    _ => Arc::new(NotFoundHandler),
+                    _ => Box::new(NotFoundHandler),
                 },
             );
         }
@@ -101,7 +101,7 @@ impl OctobotService {
             // hooks
             (&Method::POST, "/hooks/github") => GithubHandler::from_state(self.github_handler_state.clone()),
 
-            _ => Arc::new(NotFoundHandler),
+            _ => Box::new(NotFoundHandler),
         }
     }
 }

--- a/octobot/tests/check_jira_refs_test.rs
+++ b/octobot/tests/check_jira_refs_test.rs
@@ -38,8 +38,8 @@ fn expect_skip(git: &MockGithub, pr: &github::PullRequest) {
 }
 
 
-#[test]
-fn test_check_jira_refs_no_projects() {
+#[tokio::test]
+async fn test_check_jira_refs_no_projects() {
     let git = MockGithub::new();
 
     let pr = new_pr("");
@@ -48,11 +48,11 @@ fn test_check_jira_refs_no_projects() {
 
     // No assertions -- it shouldn't do anything
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_chore_commit() {
+#[tokio::test]
+async fn test_check_jira_refs_chore_commit() {
     let git = MockGithub::new();
 
     let pr = new_pr("chore: Do stuff");
@@ -61,11 +61,11 @@ fn test_check_jira_refs_chore_commit() {
 
     expect_skip(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_chore_commit_scope() {
+#[tokio::test]
+async fn test_check_jira_refs_chore_commit_scope() {
     let git = MockGithub::new();
 
     let pr = new_pr("chore(deps): Update deps");
@@ -74,11 +74,11 @@ fn test_check_jira_refs_chore_commit_scope() {
 
     expect_skip(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_build_commit() {
+#[tokio::test]
+async fn test_check_jira_refs_build_commit() {
     let git = MockGithub::new();
 
     let pr = new_pr("build: do stuff");
@@ -87,11 +87,11 @@ fn test_check_jira_refs_build_commit() {
 
     expect_skip(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_mismatch() {
+#[tokio::test]
+async fn test_check_jira_refs_mismatch() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
@@ -100,11 +100,11 @@ fn test_check_jira_refs_mismatch() {
 
     expect_failure(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_pass() {
+#[tokio::test]
+async fn test_check_jira_refs_pass() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
@@ -113,11 +113,11 @@ fn test_check_jira_refs_pass() {
 
     expect_pass(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_requires_only_one_ref() {
+#[tokio::test]
+async fn test_check_jira_refs_requires_only_one_ref() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
@@ -126,11 +126,11 @@ fn test_check_jira_refs_requires_only_one_ref() {
 
     expect_pass(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }
 
-#[test]
-fn test_check_jira_refs_checks_all_commits() {
+#[tokio::test]
+async fn test_check_jira_refs_checks_all_commits() {
     let git = MockGithub::new();
 
     let pr = new_pr("Do stuff");
@@ -142,5 +142,5 @@ fn test_check_jira_refs_checks_all_commits() {
 
     expect_pass(&git, &pr);
 
-    jira::check_jira_refs(&pr, &commits, &projects, &git);
+    jira::check_jira_refs(&pr, &commits, &projects, &git).await;
 }

--- a/octobot/tests/force_push_test.rs
+++ b/octobot/tests/force_push_test.rs
@@ -8,8 +8,8 @@ use octobot_ops::diffs::DiffOfDiffs;
 use octobot_ops::force_push;
 use octobot_lib::github;
 
-#[test]
-fn test_force_push_identical() {
+#[tokio::test]
+async fn test_force_push_identical() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
     pr.head.ref_name = "the-pr-branch".into();
@@ -36,11 +36,11 @@ fn test_force_push_identical() {
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_different() {
+#[tokio::test]
+async fn test_force_push_different() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
 
@@ -63,11 +63,11 @@ fn test_force_push_different() {
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_different_with_details() {
+#[tokio::test]
+async fn test_force_push_different_with_details() {
     let diff0 = r#"
 diff --git a/src/diffs.rs b/src/diffs.rs
 index 9c8643c..5aa6c73 100644
@@ -196,11 +196,11 @@ index 33667da..3503c28 100644
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_error() {
+#[tokio::test]
+async fn test_force_push_error() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
 
@@ -221,11 +221,11 @@ fn test_force_push_error() {
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_identical_no_previous_approve_dismissal() {
+#[tokio::test]
+async fn test_force_push_identical_no_previous_approve_dismissal() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
     pr.head.ref_name = "the-pr-branch".into();
@@ -254,11 +254,11 @@ fn test_force_push_identical_no_previous_approve_dismissal() {
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_identical_no_previous_approval() {
+#[tokio::test]
+async fn test_force_push_identical_no_previous_approval() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
     pr.head.ref_name = "the-pr-branch".into();
@@ -297,11 +297,11 @@ fn test_force_push_identical_no_previous_approval() {
         &pr,
         "abcdef0999999",
         "1111abc9999999",
-    ).unwrap();
+    ).await.unwrap();
 }
 
-#[test]
-fn test_force_push_identical_reapprove() {
+#[tokio::test]
+async fn test_force_push_identical_reapprove() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
     pr.head.ref_name = "the-pr-branch".into();
@@ -352,11 +352,12 @@ fn test_force_push_identical_reapprove() {
     );
 
     force_push::comment_force_push(diffs, &github, "some-user", "some-repo", &pr, before_hash, after_hash)
+        .await
         .unwrap();
 }
 
-#[test]
-fn test_force_push_identical_wrong_previous_approval() {
+#[tokio::test]
+async fn test_force_push_identical_wrong_previous_approval() {
     let mut pr = github::PullRequest::new();
     pr.number = 32;
     pr.head.ref_name = "the-pr-branch".into();
@@ -400,5 +401,6 @@ fn test_force_push_identical_wrong_previous_approval() {
     // Do not mock approve_pull_request: Should not re-approve
 
     force_push::comment_force_push(diffs, &github, "some-user", "some-repo", &pr, before_hash, after_hash)
+        .await
         .unwrap();
 }

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -239,17 +239,17 @@ fn expect_jira_ref_pass_pr(git: &MockGithub, pr: &PullRequest) {
 }
 
 
-#[test]
-fn test_ping() {
+#[tokio::test]
+async fn test_ping() {
     let mut test = new_test();
     test.handler.event = "ping".to_string();
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "ping".into()), resp);
 }
 
-#[test]
-fn test_commit_comment_with_path() {
+#[tokio::test]
+async fn test_commit_comment_with_path() {
     let mut test = new_test();
     test.handler.event = "commit_comment".into();
     test.handler.action = "created".into();
@@ -273,12 +273,12 @@ fn test_commit_comment_with_path() {
         )
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "commit_comment".into()), resp);
 }
 
-#[test]
-fn test_commit_comment_no_path() {
+#[tokio::test]
+async fn test_commit_comment_no_path() {
     let mut test = new_test();
     test.handler.event = "commit_comment".into();
     test.handler.action = "created".into();
@@ -302,12 +302,12 @@ fn test_commit_comment_no_path() {
         )
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "commit_comment".into()), resp);
 }
 
-#[test]
-fn test_issue_comment() {
+#[tokio::test]
+async fn test_issue_comment() {
     let mut test = new_test();
     test.handler.event = "issue_comment".into();
     test.handler.action = "created".into();
@@ -342,12 +342,12 @@ fn test_issue_comment() {
         slack::req("@mentioned.participant", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "issue_comment".into()), resp);
 }
 
-#[test]
-fn test_pull_request_comment() {
+#[tokio::test]
+async fn test_pull_request_comment() {
     let mut test = new_test();
     test.handler.event = "pull_request_review_comment".into();
     test.handler.action = "created".into();
@@ -378,12 +378,12 @@ fn test_pull_request_comment() {
         slack::req("@mentioned.participant", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review_comment".into()), resp);
 }
 
-#[test]
-fn test_pull_request_review_commented() {
+#[tokio::test]
+async fn test_pull_request_review_commented() {
     let mut test = new_test();
     test.handler.event = "pull_request_review".into();
     test.handler.action = "submitted".into();
@@ -413,12 +413,12 @@ fn test_pull_request_review_commented() {
         slack::req("@mentioned.participant", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review [comment]".into()), resp);
 }
 
-#[test]
-fn test_pull_request_comments_ignore_empty_messages() {
+#[tokio::test]
+async fn test_pull_request_comments_ignore_empty_messages() {
     let mut test = new_test();
     test.handler.event = "pull_request_review_comment".into();
     test.handler.action = "created".into();
@@ -435,12 +435,12 @@ fn test_pull_request_comments_ignore_empty_messages() {
 
     test.slack.expect(vec![]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review_comment".into()), resp);
 }
 
-#[test]
-fn test_pull_request_comments_ignore_octobot() {
+#[tokio::test]
+async fn test_pull_request_comments_ignore_octobot() {
     let mut test = new_test();
     test.handler.event = "pull_request_review_comment".into();
     test.handler.action = "created".into();
@@ -457,12 +457,12 @@ fn test_pull_request_comments_ignore_octobot() {
 
     test.slack.expect(vec![]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review_comment".into()), resp);
 }
 
-#[test]
-fn test_pull_request_review_approved() {
+#[tokio::test]
+async fn test_pull_request_review_approved() {
     let mut test = new_test();
     test.handler.event = "pull_request_review".into();
     test.handler.action = "submitted".into();
@@ -493,12 +493,12 @@ fn test_pull_request_review_approved() {
         slack::req("@mentioned.participant", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review".into()), resp);
 }
 
-#[test]
-fn test_pull_request_review_changes_requested() {
+#[tokio::test]
+async fn test_pull_request_review_changes_requested() {
     let mut test = new_test();
     test.handler.event = "pull_request_review".into();
     test.handler.action = "submitted".into();
@@ -528,12 +528,12 @@ fn test_pull_request_review_changes_requested() {
         slack::req("@mentioned.participant", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr_review".into()), resp);
 }
 
-#[test]
-fn test_pull_request_opened() {
+#[tokio::test]
+async fn test_pull_request_opened() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "opened".into();
@@ -559,12 +559,12 @@ fn test_pull_request_opened() {
         ),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_closed() {
+#[tokio::test]
+async fn test_pull_request_closed() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "closed".into();
@@ -588,12 +588,12 @@ fn test_pull_request_closed() {
         slack::req("@joe.reviewer", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_reopened() {
+#[tokio::test]
+async fn test_pull_request_reopened() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "reopened".into();
@@ -617,12 +617,12 @@ fn test_pull_request_reopened() {
         ),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_ready_for_review() {
+#[tokio::test]
+async fn test_pull_request_ready_for_review() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "ready_for_review".into();
@@ -648,12 +648,12 @@ fn test_pull_request_ready_for_review() {
         slack::req("@joe.reviewer", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_edited() {
+#[tokio::test]
+async fn test_pull_request_edited() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "edited".into();
@@ -665,12 +665,12 @@ fn test_pull_request_edited() {
 
     // no slack mocks
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_assigned() {
+#[tokio::test]
+async fn test_pull_request_assigned() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "assigned".into();
@@ -698,12 +698,12 @@ fn test_pull_request_assigned() {
         slack::req("@joe.reviewer", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_unassigned() {
+#[tokio::test]
+async fn test_pull_request_unassigned() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "unassigned".into();
@@ -727,12 +727,12 @@ fn test_pull_request_unassigned() {
         ),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_review_requested() {
+#[tokio::test]
+async fn test_pull_request_review_requested() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "review_requested".into();
@@ -760,13 +760,13 @@ fn test_pull_request_review_requested() {
         slack::req("@smith.reviewer", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
 
-#[test]
-fn test_pull_request_review_no_username() {
+#[tokio::test]
+async fn test_pull_request_review_no_username() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "review_requested".into();
@@ -792,12 +792,12 @@ fn test_pull_request_review_no_username() {
         slack::req("@bob.author", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_other() {
+#[tokio::test]
+async fn test_pull_request_other() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "some-other-action".into();
@@ -806,13 +806,13 @@ fn test_pull_request_other() {
 
     // should not do anything!
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
 
-#[test]
-fn test_pull_request_labeled_not_merged() {
+#[tokio::test]
+async fn test_pull_request_labeled_not_merged() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "labeled".into();
@@ -825,12 +825,12 @@ fn test_pull_request_labeled_not_merged() {
 
     // labeled but not merged --> noop
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_error_getting_labels() {
+#[tokio::test]
+async fn test_pull_request_merged_error_getting_labels() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "closed".into();
@@ -870,12 +870,12 @@ fn test_pull_request_merged_error_getting_labels() {
         slack::req("@the.pr.owner", msg2, attach2.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_no_labels() {
+#[tokio::test]
+async fn test_pull_request_merged_no_labels() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "closed".into();
@@ -904,12 +904,12 @@ fn test_pull_request_merged_no_labels() {
         slack::req("@joe.reviewer", msg, attach.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_backport_labels() {
+#[tokio::test]
+async fn test_pull_request_merged_backport_labels() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "closed".into();
@@ -955,12 +955,12 @@ fn test_pull_request_merged_backport_labels() {
         commits,
     );
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_backport_labels_custom_pattern() {
+#[tokio::test]
+async fn test_pull_request_merged_backport_labels_custom_pattern() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "closed".into();
@@ -1026,12 +1026,12 @@ fn test_pull_request_merged_backport_labels_custom_pattern() {
         "the-other-prefix-other-thing".into(),
     ], commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_retroactively_labeled() {
+#[tokio::test]
+async fn test_pull_request_merged_retroactively_labeled() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "labeled".into();
@@ -1046,12 +1046,12 @@ fn test_pull_request_merged_retroactively_labeled() {
 
     test.expect_will_merge_branches("release/", vec!["release/7.123".into()], commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_master_branch() {
+#[tokio::test]
+async fn test_pull_request_merged_master_branch() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "labeled".into();
@@ -1066,12 +1066,12 @@ fn test_pull_request_merged_master_branch() {
 
     test.expect_will_merge_branches("release/", vec!["master".into()], commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_develop_branch() {
+#[tokio::test]
+async fn test_pull_request_merged_develop_branch() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "labeled".into();
@@ -1086,12 +1086,12 @@ fn test_pull_request_merged_develop_branch() {
 
     test.expect_will_merge_branches("release/", vec!["develop".into()], commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_pull_request_merged_main_branch() {
+#[tokio::test]
+async fn test_pull_request_merged_main_branch() {
     let mut test = new_test();
     test.handler.event = "pull_request".into();
     test.handler.action = "labeled".into();
@@ -1106,12 +1106,12 @@ fn test_pull_request_merged_main_branch() {
 
     test.expect_will_merge_branches("release/", vec!["main".into()], commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_push_no_pr() {
+#[tokio::test]
+async fn test_push_no_pr() {
     let mut test = new_test();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/some-branch".into());
@@ -1126,12 +1126,12 @@ fn test_push_no_pr() {
         Ok(vec![]),
     );
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_push_with_pr() {
+#[tokio::test]
+async fn test_push_with_pr() {
     let mut test = new_test();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/some-branch".into());
@@ -1225,12 +1225,12 @@ fn test_push_with_pr() {
         slack::req("@bob.author", msg, attach2.clone()),
     ]);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_push_force_notify() {
+#[tokio::test]
+async fn test_push_force_notify() {
     let mut test = new_test();
 
     test.handler.event = "push".into();
@@ -1271,12 +1271,12 @@ fn test_push_force_notify() {
 
     test.expect_will_force_push_notify(&pr, "abcdef0000", "1111abcdef");
 
-    let resp = test.handler.handle_event().expect("handled event");
+    let resp = test.handler.handle_event().await.expect("handled event");
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_push_force_notify_wip() {
+#[tokio::test]
+async fn test_push_force_notify_wip() {
     let mut test = new_test();
 
     test.handler.event = "push".into();
@@ -1299,12 +1299,12 @@ fn test_push_force_notify_wip() {
 
     // Note: no expectations here.
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_push_force_notify_ignored() {
+#[tokio::test]
+async fn test_push_force_notify_ignored() {
     let mut test = new_test();
 
     test.handler.event = "push".into();
@@ -1351,7 +1351,7 @@ fn test_push_force_notify_ignored() {
 
     // Note: no expectations here.
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
@@ -1417,8 +1417,8 @@ fn some_jira_push_commits() -> Vec<PushCommit> {
     ]
 }
 
-#[test]
-fn test_jira_pull_request_opened() {
+#[tokio::test]
+async fn test_jira_pull_request_opened() {
     let mut test = new_test_with_jira();
     test.handler.event = "pull_request".into();
     test.handler.action = "opened".into();
@@ -1466,12 +1466,12 @@ fn test_jira_pull_request_opened() {
         jira.mock_transition_issue("SER-1", &new_transition_req("002"), Ok(()));
     }
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_jira_pull_request_opened_too_many_commits() {
+#[tokio::test]
+async fn test_jira_pull_request_opened_too_many_commits() {
     let mut test = new_test_with_jira();
     test.handler.event = "pull_request".into();
     test.handler.action = "opened".into();
@@ -1514,12 +1514,12 @@ fn test_jira_pull_request_opened_too_many_commits() {
 
     // do not set jira expectations
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "pr".into()), resp);
 }
 
-#[test]
-fn test_jira_push_master() {
+#[tokio::test]
+async fn test_jira_push_master() {
     let mut test = new_test_with_jira();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/master".into());
@@ -1530,12 +1530,12 @@ fn test_jira_push_master() {
 
     test.expect_will_run_version_script("master", "1111abcdef", &commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_jira_push_develop() {
+#[tokio::test]
+async fn test_jira_push_develop() {
     let mut test = new_test_with_jira();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/develop".into());
@@ -1546,12 +1546,12 @@ fn test_jira_push_develop() {
 
     test.expect_will_run_version_script("develop", "1111abcdef", &commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_jira_push_release() {
+#[tokio::test]
+async fn test_jira_push_release() {
     let mut test = new_test_with_jira();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/release/55".into());
@@ -1562,12 +1562,12 @@ fn test_jira_push_release() {
 
     test.expect_will_run_version_script("release/55", "1111abcdef", &commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_jira_push_other_branch() {
+#[tokio::test]
+async fn test_jira_push_other_branch() {
     let mut test = new_test_with_jira();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/some-branch".into());
@@ -1586,13 +1586,13 @@ fn test_jira_push_other_branch() {
 
     // no jira mocks: will fail if called
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
 
-#[test]
-fn test_jira_disabled() {
+#[tokio::test]
+async fn test_jira_disabled() {
     let mut test = new_test_with_jira();
     test.handler.event = "push".into();
     test.handler.data.ref_name = Some("refs/heads/master".into());
@@ -1607,12 +1607,12 @@ fn test_jira_disabled() {
 
     // no jira mocks: will fail if called
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }
 
-#[test]
-fn test_jira_push_triggers_version_script() {
+#[tokio::test]
+async fn test_jira_push_triggers_version_script() {
     let mut test = new_test_with_jira();
 
     test.config
@@ -1635,6 +1635,6 @@ fn test_jira_push_triggers_version_script() {
 
     test.expect_will_run_version_script("master", "1111abcdef", &commits);
 
-    let resp = test.handler.handle_event().unwrap();
+    let resp = test.handler.handle_event().await.unwrap();
     assert_eq!((StatusCode::OK, "push".into()), resp);
 }

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -139,6 +139,7 @@ impl Drop for MockGithub {
     }
 }
 
+#[async_trait::async_trait]
 impl Session for MockGithub {
     fn bot_name(&self) -> &str {
         "octobot[bot]"
@@ -156,7 +157,7 @@ impl Session for MockGithub {
         Some(2)
     }
 
-    fn get_pull_request(&self, owner: &str, repo: &str, number: u32) -> Result<PullRequest> {
+    async fn get_pull_request(&self, owner: &str, repo: &str, number: u32) -> Result<PullRequest> {
         let mut calls = self.get_pr_calls.lock().unwrap();
         if calls.len() == 0 {
             panic!("Unexpected call to get_pull_request");
@@ -169,7 +170,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_pull_requests(
+    async fn get_pull_requests(
         &self,
         owner: &str,
         repo: &str,
@@ -187,7 +188,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn create_pull_request(
+    async fn create_pull_request(
         &self,
         owner: &str,
         repo: &str,
@@ -209,7 +210,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_pull_request_labels(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Label>> {
+    async fn get_pull_request_labels(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Label>> {
         let mut calls = self.get_pr_labels_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_pull_request_labels");
         let call = calls.remove(0);
@@ -220,7 +221,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn add_pull_request_labels(&self, owner: &str, repo: &str, number: u32, labels: Vec<String>) -> Result<()> {
+    async fn add_pull_request_labels(&self, owner: &str, repo: &str, number: u32, labels: Vec<String>) -> Result<()> {
         let mut calls = self.add_pr_labels_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to add_pull_request_labels");
         let call = calls.remove(0);
@@ -232,7 +233,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Commit>> {
+    async fn get_pull_request_commits(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Commit>> {
         let mut calls = self.get_pr_commits_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_pull_request_commits");
         let call = calls.remove(0);
@@ -243,7 +244,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_pull_request_reviews(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Review>> {
+    async fn get_pull_request_reviews(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<Review>> {
         let mut calls = self.get_pr_reviews_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_pull_request_reviews");
         let call = calls.remove(0);
@@ -254,7 +255,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn assign_pull_request(&self, owner: &str, repo: &str, number: u32, assignees: Vec<String>) -> Result<()> {
+    async fn assign_pull_request(&self, owner: &str, repo: &str, number: u32, assignees: Vec<String>) -> Result<()> {
         let mut calls = self.assign_pr_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to assign_pull_request");
         let call = calls.remove(0);
@@ -266,7 +267,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn request_review(&self, owner: &str, repo: &str, number: u32, reviewers: Vec<String>) -> Result<()> {
+    async fn request_review(&self, owner: &str, repo: &str, number: u32, reviewers: Vec<String>) -> Result<()> {
         let mut calls = self.request_review_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to request_review");
         let call = calls.remove(0);
@@ -278,7 +279,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn comment_pull_request(&self, owner: &str, repo: &str, number: u32, comment: &str) -> Result<()> {
+    async fn comment_pull_request(&self, owner: &str, repo: &str, number: u32, comment: &str) -> Result<()> {
         let mut calls = self.comment_pr_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to comment_pull_request");
         let call = calls.remove(0);
@@ -290,7 +291,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn create_branch(&self, owner: &str, repo: &str, branch_name: &str, sha: &str) -> Result<()> {
+    async fn create_branch(&self, owner: &str, repo: &str, branch_name: &str, sha: &str) -> Result<()> {
         let mut calls = self.create_branch_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to create_branch");
         let call = calls.remove(0);
@@ -302,7 +303,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> Result<()> {
+    async fn delete_branch(&self, owner: &str, repo: &str, branch_name: &str) -> Result<()> {
         let mut calls = self.create_branch_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to delete_branch");
         let call = calls.remove(0);
@@ -313,7 +314,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn approve_pull_request(
+    async fn approve_pull_request(
         &self,
         owner: &str,
         repo: &str,
@@ -333,7 +334,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_timeline(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<TimelineEvent>> {
+    async fn get_timeline(&self, owner: &str, repo: &str, number: u32) -> Result<Vec<TimelineEvent>> {
         let mut calls = self.get_timeline_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_timeline");
         let call = calls.remove(0);
@@ -344,7 +345,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_suites(&self, pr: &PullRequest) -> Result<Vec<CheckSuite>> {
+    async fn get_suites(&self, pr: &PullRequest) -> Result<Vec<CheckSuite>> {
         let mut calls = self.get_suites_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_suites");
         let call = calls.remove(0);
@@ -353,7 +354,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn get_check_run(&self, pr: &PullRequest, id: u32) -> Result<CheckRun> {
+    async fn get_check_run(&self, pr: &PullRequest, id: u32) -> Result<CheckRun> {
         let mut calls = self.get_check_run_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_check_run");
         let call = calls.remove(0);
@@ -362,7 +363,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn create_check_run(&self, pr: &PullRequest, run: &CheckRun) -> Result<u32> {
+    async fn create_check_run(&self, pr: &PullRequest, run: &CheckRun) -> Result<u32> {
         let mut calls = self.create_check_run_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to create_check_run");
         let call = calls.remove(0);
@@ -372,7 +373,7 @@ impl Session for MockGithub {
         call.ret
     }
 
-    fn update_check_run(&self, pr: &PullRequest, check_run_id: u32, run: &CheckRun) -> Result<()> {
+    async fn update_check_run(&self, pr: &PullRequest, check_run_id: u32, run: &CheckRun) -> Result<()> {
         let mut calls = self.update_check_run_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to update_check_run");
         let call = calls.remove(0);

--- a/octobot/tests/mocks/mock_jira.rs
+++ b/octobot/tests/mocks/mock_jira.rs
@@ -116,8 +116,9 @@ impl Drop for MockJira {
     }
 }
 
+#[async_trait::async_trait]
 impl Session for MockJira {
-    fn get_issue(&self, key: &str) -> Result<Issue> {
+    async fn get_issue(&self, key: &str) -> Result<Issue> {
         let mut calls = self.get_issue_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_issue {}", key);
         let call = calls.remove(0);
@@ -125,7 +126,7 @@ impl Session for MockJira {
 
         call.ret
     }
-    fn get_transitions(&self, key: &str) -> Result<Vec<Transition>> {
+    async fn get_transitions(&self, key: &str) -> Result<Vec<Transition>> {
         let mut calls = self.get_transitions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_transitions");
         let call = calls.remove(0);
@@ -134,7 +135,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn transition_issue(&self, key: &str, req: &TransitionRequest) -> Result<()> {
+    async fn transition_issue(&self, key: &str, req: &TransitionRequest) -> Result<()> {
         let mut calls = self.transition_issue_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to transition_issue");
         let call = calls.remove(0);
@@ -144,7 +145,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn comment_issue(&self, key: &str, comment: &str) -> Result<()> {
+    async fn comment_issue(&self, key: &str, comment: &str) -> Result<()> {
         let mut calls = self.comment_issue_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to comment_issue");
         let call = calls.remove(0);
@@ -154,7 +155,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn add_version(&self, proj: &str, version: &str) -> Result<()> {
+    async fn add_version(&self, proj: &str, version: &str) -> Result<()> {
         let mut calls = self.add_version_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to add_version");
         let call = calls.remove(0);
@@ -164,7 +165,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn get_versions(&self, proj: &str) -> Result<Vec<Version>> {
+    async fn get_versions(&self, proj: &str) -> Result<Vec<Version>> {
         let mut calls = self.get_versions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_versions");
         let call = calls.remove(0);
@@ -173,7 +174,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn assign_fix_version(&self, key: &str, version: &str) -> Result<()> {
+    async fn assign_fix_version(&self, key: &str, version: &str) -> Result<()> {
         let mut calls = self.assign_fix_version_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to assign_fix_version");
         let call = calls.remove(0);
@@ -183,7 +184,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn reorder_version(&self, version: &Version, position: JiraVersionPosition) -> Result<()> {
+    async fn reorder_version(&self, version: &Version, position: JiraVersionPosition) -> Result<()> {
         let mut calls = self.reorder_version_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to reorder_version");
         let call = calls.remove(0);
@@ -193,7 +194,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn add_pending_version(&self, key: &str, version: &str) -> Result<()> {
+    async fn add_pending_version(&self, key: &str, version: &str) -> Result<()> {
         let mut calls = self.add_pending_version_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to add_pending_version");
         let call = calls.remove(0);
@@ -203,7 +204,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn remove_pending_versions(&self, key: &str, versions: &Vec<version::Version>) -> Result<()> {
+    async fn remove_pending_versions(&self, key: &str, versions: &Vec<version::Version>) -> Result<()> {
         let mut calls = self.remove_pending_versions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to remove_pending_versions");
         let call = calls.remove(0);
@@ -213,7 +214,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    fn find_pending_versions(&self, proj: &str) -> Result<HashMap<String, Vec<version::Version>>> {
+    async fn find_pending_versions(&self, proj: &str) -> Result<HashMap<String, Vec<version::Version>>> {
         let mut calls = self.find_pending_versions_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to find_pending_versions");
         let call = calls.remove(0);

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -47,8 +47,8 @@ fn new_test() -> (PRMergeTest, TempDir) {
     }, temp_dir)
 }
 
-#[test]
-fn test_pr_merge_basic() {
+#[tokio::test]
+async fn test_pr_merge_basic() {
     let (test, _temp_dir) = new_test();
 
     // setup a release branch
@@ -107,7 +107,7 @@ fn test_pr_merge_basic() {
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", vec![]);
-    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender());
+    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender()).await;
 
     let (user, email) = test.git.git.get_commit_author("origin/my-feature-branch-1.0").unwrap();
 
@@ -117,8 +117,8 @@ fn test_pr_merge_basic() {
     assert_eq!("", test.git.run_git(&["diff", "master", "origin/my-feature-branch-1.0"]));
 }
 
-#[test]
-fn test_pr_merge_ignore_space_change() {
+#[tokio::test]
+async fn test_pr_merge_ignore_space_change() {
     let (test, _temp_dir) = new_test();
 
     let contents_base = "
@@ -204,13 +204,13 @@ if (true)    {
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", vec![]);
-    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender());
+    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender()).await;
 
     assert_eq!(contents_10_final, test.git.run_git(&["cat-file", "blob", "my-feature-branch-1.0:file.cpp"]));
 }
 
-#[test]
-fn test_pr_merge_ignore_all_space() {
+#[tokio::test]
+async fn test_pr_merge_ignore_all_space() {
     let (test, _temp_dir) = new_test();
 
     let contents_base = "
@@ -295,13 +295,13 @@ if (true) {
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", vec![]);
-    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender());
+    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender()).await;
 
     assert_eq!(contents_10_final, test.git.run_git(&["cat-file", "blob", "my-feature-branch-1.0:file.cpp"]));
 }
 
-#[test]
-fn test_pr_merge_conventional_commit() {
+#[tokio::test]
+async fn test_pr_merge_conventional_commit() {
     let (test, _temp_dir) = new_test();
 
     // setup a release branch
@@ -360,7 +360,7 @@ fn test_pr_merge_conventional_commit() {
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", vec![]);
-    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender());
+    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender()).await;
 
     let (user, email) = test.git.git.get_commit_author("origin/my-feature-branch-1.0").unwrap();
 
@@ -370,8 +370,8 @@ fn test_pr_merge_conventional_commit() {
     assert_eq!("", test.git.run_git(&["diff", "master", "origin/my-feature-branch-1.0"]));
 }
 
-#[test]
-fn test_pr_merge_backport_failure() {
+#[tokio::test]
+async fn test_pr_merge_backport_failure() {
     let (mut test, _temp_dir) = new_test();
 
     // setup a release branch
@@ -439,5 +439,5 @@ fn test_pr_merge_backport_failure() {
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", vec![]);
-    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender());
+    pr_merge::merge_pull_request(&test.git.git, &test.github, &req, test.config, test.slack.new_sender()).await;
 }

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -13,18 +13,16 @@ path = "src/lib.rs"
 octobot_lib = { "path" = "../lib" }
 conventional = "0.5.0"
 failure = "0.1.5"
-futures = "0.1.25"
-hyper = "0.12.25"
+hyper = "0.14.13"
 log = "0.4.6"
 regex = "1.1.2"
 serde = "1.0.89"
 serde_derive = "1.0.89"
 time = "0.1.42"
-tokio = "0.1.17"
+tokio = { version = "1.12.0", features = ["rt"]}
 unidiff = "0.3.2"
-
-[dependencies.reqwest]
-version = "0.9.12"
+reqwest = { version = "0.11.4", features = ["json"]}
+async-trait = "0.1.51"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -71,6 +71,7 @@ struct SlackMessage {
 
 // the main object for sending messages to slack
 struct Slack {
+    client: reqwest::Client,
     webhook_url: String,
     recent_messages: Mutex<Vec<SlackMessage>>,
 }
@@ -81,6 +82,7 @@ const TRIM_MESSAGES_TO: usize = 20;
 impl Slack {
     pub fn new(webhook_url: Option<String>) -> Slack {
         Slack {
+            client: reqwest::Client::new(),
             webhook_url: webhook_url.unwrap_or(String::new()),
             recent_messages: Mutex::new(Vec::new()),
         }
@@ -104,8 +106,8 @@ impl Slack {
 
         info!("Sending message to #{}", channel);
         let webhook_url = self.webhook_url.clone();
+        let client = self.client.clone();
         tokio::spawn(async move {
-            let client = reqwest::Client::new();
             let res = client.post(&webhook_url).json(&slack_msg).send().await;
             match res {
                 Ok(_) => info!("Successfully sent slack message"),

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/octobot-passwd.rs"
 
 [dependencies]
 rpassword = "3.0.0"
-ring = "0.14.6"
+ring = "0.16.20"
 rustc-serialize = "0.3.24"
 regex = "1.1.2"
 octobot_lib = { "path" = "../lib" }


### PR DESCRIPTION
Update to latest versions of tokio, hyper, reqwest, etc. and finally
adopt async-await patterns!

Notably, octobot no longer uses a blocking http client, which was
a major bottleneck to block inbound connections on outbound api calls.

Note: Some admin api handlers may return http 500 instead of 400
now for invalid json. This was to simply the `parse_json` interface
and can be improved in the future with better error types.
