### PR TITLE
"Use" process_collector on linux only

### DIFF
--- a/lib/src/metrics.rs
+++ b/lib/src/metrics.rs
@@ -1,6 +1,5 @@
 #[cfg(target_os = "linux")]
 use prometheus::process_collector::ProcessCollector;
-
 use prometheus::Registry;
 use prometheus::{register_gauge_vec_with_registry, GaugeVec};
 use prometheus::{register_gauge_with_registry, Gauge};


### PR DESCRIPTION
The process collector is only used in linux, but the 'use' statement was
not conditional so the build would fail on mac.