### PR TITLE
Fix race condition applying jira check suite

### DIFF
--- a/lib/src/github/models_checks.rs
+++ b/lib/src/github/models_checks.rs
@@ -85,10 +85,10 @@ pub enum CheckStatus {
 }
 
 impl CheckRun {
-    pub fn new(name: &str, pr: &models::PullRequest, url: Option<String>) -> CheckRun {
+    pub fn new(name: &str, commit_sha: &str, url: Option<String>) -> CheckRun {
         CheckRun {
             name: name.into(),
-            head_sha: pr.head.sha.clone(),
+            head_sha: commit_sha.to_string(),
             status: CheckStatus::InProgress,
             conclusion: None,
             completed_at: None,

--- a/lib/src/jira/api.rs
+++ b/lib/src/jira/api.rs
@@ -377,7 +377,7 @@ impl Session for JiraSession {
 fn parse_pending_version_field(field: &serde_json::Value) -> Vec<version::Version> {
     let re = Regex::new(r"\s*,\s*").unwrap();
     re.split(field.as_str().unwrap_or("").trim())
-        .filter_map(|s| version::Version::parse(s))
+        .filter_map(version::Version::parse)
         .collect::<Vec<_>>()
 }
 

--- a/lib/src/jira/check_jira_refs.rs
+++ b/lib/src/jira/check_jira_refs.rs
@@ -22,7 +22,7 @@ pub async fn check_jira_refs(
 
     // Skip PRs titled accordingly.
     if let Some(commit_type) = conventional_commit_jira_skip_type(&pull_request.title) {
-        if let Err(e) = do_skip_jira_check(pull_request, commit_type, github).await {
+        if let Err(e) = do_skip_jira_check(pull_request, &commits, commit_type, github).await {
             log::error!("Error marking skipped jira refs: {}", e);
         }
         return;
@@ -41,7 +41,12 @@ async fn do_check_jira_refs(
     projects: &[String],
     github: &dyn github::api::Session,
 ) -> Result<()> {
-    let mut run = github::CheckRun::new(JIRA_REF_CONTEXT, pull_request, None);
+    let mut run = github::CheckRun::new(
+        JIRA_REF_CONTEXT,
+        get_latest_commit_hash(pull_request, commits),
+        None,
+    );
+
     if jira::workflow::get_all_jira_keys(commits, projects).is_empty() {
         run = run.completed(github::Conclusion::Neutral);
 
@@ -84,17 +89,34 @@ fn conventional_commit_jira_skip_type(title: &str) -> Option<&str> {
 
 async fn do_skip_jira_check(
     pull_request: &github::PullRequest,
+    commits: &[github::Commit],
     commit_type: &str,
     github: &dyn github::api::Session,
 ) -> Result<()> {
     let msg = "Skipped JIRA check";
     let body = format!("Skipped JIRA check for commit type: {}", commit_type);
 
-    let mut run = github::CheckRun::new(JIRA_REF_CONTEXT, pull_request, None);
+    let mut run = github::CheckRun::new(
+        JIRA_REF_CONTEXT,
+        get_latest_commit_hash(pull_request, commits),
+        None,
+    );
+
     run = run.completed(github::Conclusion::Neutral);
     run.output = Some(github::CheckOutput::new(msg, &body));
 
     github.create_check_run(pull_request, &run).await?;
 
     Ok(())
+}
+
+fn get_latest_commit_hash<'a>(
+    pull_request: &'a github::PullRequest,
+    commits: &'a [github::Commit],
+) -> &'a str {
+    if commits.is_empty() {
+        &pull_request.head.sha
+    } else {
+        &commits.last().unwrap().sha
+    }
 }

--- a/lib/src/jira/check_jira_refs.rs
+++ b/lib/src/jira/check_jira_refs.rs
@@ -22,7 +22,7 @@ pub async fn check_jira_refs(
 
     // Skip PRs titled accordingly.
     if let Some(commit_type) = conventional_commit_jira_skip_type(&pull_request.title) {
-        if let Err(e) = do_skip_jira_check(pull_request, &commits, commit_type, github).await {
+        if let Err(e) = do_skip_jira_check(pull_request, commits, commit_type, github).await {
             log::error!("Error marking skipped jira refs: {}", e);
         }
         return;
@@ -50,15 +50,14 @@ async fn do_check_jira_refs(
     if jira::workflow::get_all_jira_keys(commits, projects).is_empty() {
         run = run.completed(github::Conclusion::Neutral);
 
-        let msg: String;
-        if projects.len() == 1 {
-            msg = format!(
+        let msg = if projects.len() == 1 {
+            format!(
                 "Expected a JIRA reference in a commit message for the project {}",
                 projects[0]
-            );
+            )
         } else {
-            msg = format!("Expected a JIRA reference in a commit message for at least one of the following projects: {}", projects.join(", "))
-        }
+            format!("Expected a JIRA reference in a commit message for at least one of the following projects: {}", projects.join(", "))
+        };
         run.output = Some(github::CheckOutput::new("Missing JIRA reference", &msg));
     } else {
         run = run.completed(github::Conclusion::Success);

--- a/octobot/src/main.rs
+++ b/octobot/src/main.rs
@@ -74,12 +74,11 @@ fn setup_logging() {
         .format(formatter)
         .filter(None, log::LevelFilter::Info);
 
-    let is_info;
-    if let Ok(ref env_log) = std::env::var("RUST_LOG") {
-        is_info = env_log.is_empty() || env_log.to_lowercase() == "info";
+    let is_info = if let Ok(ref env_log) = std::env::var("RUST_LOG") {
+        env_log.is_empty() || env_log.to_lowercase() == "info"
     } else {
-        is_info = true;
-    }
+        true
+    };
 
     if is_info {
         builder.filter(Some("rustls"), log::LevelFilter::Warn);

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -718,12 +718,11 @@ impl GithubEventHandler {
                 if let Some(ref commit_id) = comment.commit_id {
                     let commit: &str = &commit_id[0..7];
                     let commit_url = format!("{}/commit/{}", self.repository.html_url, commit_id);
-                    let commit_path: String;
-                    if let Some(ref path) = comment.path {
-                        commit_path = path.to_string();
+                    let commit_path = if let Some(ref path) = comment.path {
+                        path.to_string()
                     } else {
-                        commit_path = commit.to_string();
-                    }
+                        commit.to_string()
+                    };
 
                     let msg = format!(
                         "Comment on \"{}\" ({})",
@@ -830,9 +829,8 @@ impl GithubEventHandler {
                 if prs.is_empty() {
                     info!("No PRs found for '{}' ({})", branch_name, self.data.after());
                 } else {
-                    let attachments: Vec<_>;
-                    if let Some(ref commits) = self.data.commits {
-                        attachments = commits
+                    let attachments: Vec<_> = if let Some(ref commits) = self.data.commits {
+                        commits
                             .iter()
                             .map(|commit| {
                                 let msg = commit.message.lines().next().unwrap_or("");
@@ -841,10 +839,10 @@ impl GithubEventHandler {
                                     format!("{}: {}", util::make_link(&commit.url, hash), msg);
                                 SlackAttachmentBuilder::new(&attach).build()
                             })
-                            .collect();
+                            .collect()
                     } else {
-                        attachments = vec![];
-                    }
+                        vec![]
+                    };
 
                     let message = format!(
                         "{} pushed {} commit(s) to branch {}",

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -272,24 +272,25 @@ fn some_commits() -> Vec<Commit> {
 }
 
 fn expect_jira_ref_fail(git: &MockGithub) {
-    expect_jira_ref_fail_pr(git, some_pr().as_ref().unwrap())
+    expect_jira_ref_fail_pr(git, some_pr().as_ref().unwrap(), &some_commits())
 }
 
-fn expect_jira_ref_fail_pr(git: &MockGithub, pr: &PullRequest) {
-    let mut run = CheckRun::new("jira", pr, None).completed(Conclusion::Neutral);
+fn expect_jira_ref_fail_pr(git: &MockGithub, pr: &PullRequest, commits: &[Commit]) {
+    let mut run =
+        CheckRun::new("jira", &commits.last().unwrap().sha, None).completed(Conclusion::Neutral);
     run.output = Some(CheckOutput::new("Missing JIRA reference", ""));
 
     git.mock_create_check_run(pr, &run, Ok(1));
 }
 
 fn expect_jira_ref_pass(git: &MockGithub) {
-    expect_jira_ref_pass_pr(git, some_pr().as_ref().unwrap())
+    expect_jira_ref_pass_pr(git, some_pr().as_ref().unwrap(), &some_commits())
 }
 
-fn expect_jira_ref_pass_pr(git: &MockGithub, pr: &PullRequest) {
+fn expect_jira_ref_pass_pr(git: &MockGithub, pr: &PullRequest, commits: &[Commit]) {
     git.mock_create_check_run(
         pr,
-        &CheckRun::new("jira", pr, None).completed(Conclusion::Success),
+        &CheckRun::new("jira", &commits.last().unwrap().sha, None).completed(Conclusion::Success),
         Ok(1),
     );
 }
@@ -1260,8 +1261,8 @@ async fn test_push_with_pr() {
     pr2.requested_reviewers = None;
 
     // no jira references here: should fail
-    expect_jira_ref_fail_pr(&test.github, &pr1);
-    expect_jira_ref_fail_pr(&test.github, &pr2);
+    expect_jira_ref_fail_pr(&test.github, &pr1, &some_commits());
+    expect_jira_ref_fail_pr(&test.github, &pr2, &some_commits());
 
     test.github
         .mock_get_pull_request_commits("some-user", "some-repo", 32, Ok(some_commits()));
@@ -1341,7 +1342,7 @@ async fn test_push_force_notify() {
 
     test.mock_pull_request_commits();
 
-    expect_jira_ref_fail_pr(&test.github, &pr);
+    expect_jira_ref_fail_pr(&test.github, &pr, &some_commits());
 
     let msg = "joe.sender pushed 0 commit(s) to branch some-branch";
     let attach = vec![SlackAttachmentBuilder::new("")
@@ -1421,7 +1422,7 @@ async fn test_push_force_notify_ignored() {
         32,
         Ok(some_commits()),
     );
-    expect_jira_ref_fail_pr(&test.github, &pr);
+    expect_jira_ref_fail_pr(&test.github, &pr, &some_commits());
 
     let msg = "joe.sender pushed 0 commit(s) to branch some-branch";
     let attach = vec![SlackAttachmentBuilder::new("")

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -283,10 +283,6 @@ fn expect_jira_ref_fail_pr(git: &MockGithub, pr: &PullRequest, commits: &[Commit
     git.mock_create_check_run(pr, &run, Ok(1));
 }
 
-fn expect_jira_ref_pass(git: &MockGithub) {
-    expect_jira_ref_pass_pr(git, some_pr().as_ref().unwrap(), &some_commits())
-}
-
 fn expect_jira_ref_pass_pr(git: &MockGithub, pr: &PullRequest, commits: &[Commit]) {
     git.mock_create_check_run(
         pr,
@@ -1535,7 +1531,11 @@ async fn test_jira_pull_request_opened() {
         &attach,
     )]);
 
-    expect_jira_ref_pass(&test.github);
+    expect_jira_ref_pass_pr(
+        &test.github,
+        some_pr().as_ref().unwrap(),
+        &some_jira_commits(),
+    );
 
     if let Some(ref jira) = test.jira {
         jira.mock_comment_issue(
@@ -1572,7 +1572,11 @@ async fn test_jira_pull_request_opened_too_many_commits() {
         Ok(many_jira_commits()),
     );
 
-    expect_jira_ref_pass(&test.github);
+    expect_jira_ref_pass_pr(
+        &test.github,
+        some_pr().as_ref().unwrap(),
+        &some_jira_commits(),
+    );
 
     let attach = vec![SlackAttachmentBuilder::new("")
         .title("Pull Request #32: \"The PR\"")

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -664,11 +664,12 @@ fn format_check_run(run: &CheckRun) -> String {
     };
 
     format!(
-        "{}, {:?}, {}",
+        "{}, {:?}, {}, {}",
         run.name,
         run.conclusion
             .as_ref()
             .unwrap_or(&Conclusion::ActionRequired),
+        run.head_sha,
         output
     )
 }

--- a/ops/src/pr_merge.rs
+++ b/ops/src/pr_merge.rs
@@ -132,15 +132,14 @@ pub async fn try_merge_pull_request(
         ));
     }
 
-    let merge_commit_sha;
-    if let Some(ref sha) = pull_request.merge_commit_sha {
-        merge_commit_sha = sha;
+    let merge_commit_sha = if let Some(ref sha) = pull_request.merge_commit_sha {
+        sha
     } else {
         return Err(format_err!(
             "Pull Request #{} has no merge commit.",
             pull_request.number
         ));
-    }
+    };
 
     // strip everything before last slash
     let regex = Regex::new(r".*/").unwrap();

--- a/ops/src/util.rs
+++ b/ops/src/util.rs
@@ -7,9 +7,9 @@ use failure::format_err;
 use octobot_lib::errors::*;
 
 fn escape_for_slack(str: &str) -> String {
-    str.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
+    str.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 pub fn make_link(url: &str, text: &str) -> String {


### PR DESCRIPTION
It appears we've hit another race condition in the github api.
We re-fetch the PR when processing the webhook in order to fetch all
reviewers/assignees, since the PR object received in the webhook
request body is not complete.

When we fetch the PR in the webhook, we are getting back an old
`head.sha` value, not the value of the current push in question.

Update to use the commit hash instead when creating the check-run.
This seems slightly more correct anyway, since these commits are
the ones we're checking for jira references, it makes sense that
these commits are the ones we should apply the check-run to.
