### PR TITLE
feat: allow threading of messages

### DIFF
--- a/lib/src/config_db_migrations.rs
+++ b/lib/src/config_db_migrations.rs
@@ -69,6 +69,7 @@ pub fn all_migrations() -> Vec<Box<dyn Migration>> {
     "#),
         sql(r#"alter table users add column slack_id varchar not null default ''"#),
         sql(r#"alter table users add column email varchar not null default ''"#),
+        sql(r#"alter table repos add column use_threads tinyint not null default 0"#),
     ]
 }
 

--- a/lib/src/config_db_migrations.rs
+++ b/lib/src/config_db_migrations.rs
@@ -69,7 +69,7 @@ pub fn all_migrations() -> Vec<Box<dyn Migration>> {
     "#),
         sql(r#"alter table users add column slack_id varchar not null default ''"#),
         sql(r#"alter table users add column email varchar not null default ''"#),
-        sql(r#"alter table repos add column use_threads tinyint not null default 0"#),
+        sql(r#"alter table repos add column use_threads tinyint not null default 1"#),
     ]
 }
 

--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -505,7 +505,15 @@ impl Session for GithubSession {
                     page
                 ))
                 .await
-                .map_err(|e| format_err!("Error looking up PRs for commit: {}/{}/{}: {}", owner, repo, commit, e))
+                .map_err(|e| {
+                    format_err!(
+                        "Error looking up PRs for commit: {}/{}/{}: {}",
+                        owner,
+                        repo,
+                        commit,
+                        e
+                    )
+                })
                 .map(|prs| {
                     prs.into_iter()
                         .filter(|p| {

--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -383,6 +383,59 @@ impl GithubSession {
             app_id,
         })
     }
+
+    async fn do_get_pull_requests(
+        &self,
+        owner: &str,
+        repo: &str,
+        head: Option<&str>,
+        paging_url: &str,
+        err_fmt: &str,
+    ) -> Result<Vec<PullRequest>> {
+        let mut pull_requests = vec![];
+        let mut page = 1;
+        loop {
+            let mut next_prs: Vec<PullRequest> = match self
+                .client
+                .get::<Vec<PullRequest>>(&format!("{}&page={}", paging_url, page))
+                .await
+                .map_err(|e| format_err!("{}: {}", err_fmt, e))
+                .map(|prs| {
+                    prs.into_iter()
+                        .filter(|p| {
+                            if let Some(head) = head {
+                                p.head.ref_name == head || p.head.sha == head
+                            } else {
+                                true
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                }) {
+                Ok(r) => r,
+                Err(e) => return Err(e),
+            };
+
+            if next_prs.is_empty() {
+                break;
+            }
+
+            for pull_request in &mut next_prs {
+                if pull_request.reviews.is_none() {
+                    match self
+                        .get_pull_request_reviews(owner, repo, pull_request.number)
+                        .await
+                    {
+                        Ok(r) => pull_request.reviews = Some(r),
+                        Err(e) => error!("Error refetching pull request reviews: {}", e),
+                    };
+                }
+            }
+
+            pull_requests.extend(next_prs.into_iter());
+            page += 1;
+        }
+        Ok(pull_requests)
+    }
 }
 
 #[async_trait]
@@ -429,58 +482,17 @@ impl Session for GithubSession {
         state: Option<&str>,
         head: Option<&str>,
     ) -> Result<Vec<PullRequest>> {
-        let mut pull_requests = vec![];
-        let mut page = 1;
-
-        loop {
-            let mut next_prs: Vec<PullRequest> = match self
-                .client
-                .get::<Vec<PullRequest>>(&format!(
-                    "repos/{}/{}/pulls?state={}&head={}&per_page=100&page={}",
-                    owner,
-                    repo,
-                    state.unwrap_or(""),
-                    head.unwrap_or(""),
-                    page
-                ))
-                .await
-                .map_err(|e| format_err!("Error looking up PRs: {}/{}: {}", owner, repo, e))
-                .map(|prs| {
-                    prs.into_iter()
-                        .filter(|p| {
-                            if let Some(head) = head {
-                                p.head.ref_name == head || p.head.sha == head
-                            } else {
-                                true
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                }) {
-                Ok(r) => r,
-                Err(e) => return Err(e),
-            };
-
-            if next_prs.is_empty() {
-                break;
-            }
-
-            for pull_request in &mut next_prs {
-                if pull_request.reviews.is_none() {
-                    match self
-                        .get_pull_request_reviews(owner, repo, pull_request.number)
-                        .await
-                    {
-                        Ok(r) => pull_request.reviews = Some(r),
-                        Err(e) => error!("Error refetching pull request reviews: {}", e),
-                    };
-                }
-            }
-
-            pull_requests.extend(next_prs.into_iter());
-            page += 1;
-        }
-
-        Ok(pull_requests)
+        let paging_url = &format!(
+            "repos/{}/{}/pulls?state={}&head={}&per_page=100",
+            owner,
+            repo,
+            state.unwrap_or(""),
+            head.unwrap_or(""),
+        );
+        let err_fmt = &format!("Error looking up PRs for commit: {}/{}", owner, repo);
+        return self
+            .do_get_pull_requests(owner, repo, head, paging_url, err_fmt)
+            .await;
     }
 
     async fn get_pull_requests_by_commit(
@@ -490,66 +502,20 @@ impl Session for GithubSession {
         commit: &str,
         head: Option<&str>,
     ) -> Result<Vec<PullRequest>> {
-        let mut pull_requests = vec![];
-        let mut page = 1;
-
-        loop {
-            let mut next_prs: Vec<PullRequest> = match self
-                .client
-                .get::<Vec<PullRequest>>(&format!(
-                    "repos/{}/{}/commits/{}/pulls?head={}&per_page=100&page={}",
-                    owner,
-                    repo,
-                    commit,
-                    head.unwrap_or(""),
-                    page
-                ))
-                .await
-                .map_err(|e| {
-                    format_err!(
-                        "Error looking up PRs for commit: {}/{}/{}: {}",
-                        owner,
-                        repo,
-                        commit,
-                        e
-                    )
-                })
-                .map(|prs| {
-                    prs.into_iter()
-                        .filter(|p| {
-                            if let Some(head) = head {
-                                p.head.ref_name == head || p.head.sha == head
-                            } else {
-                                true
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                }) {
-                Ok(r) => r,
-                Err(e) => return Err(e),
-            };
-
-            if next_prs.is_empty() {
-                break;
-            }
-
-            for pull_request in &mut next_prs {
-                if pull_request.reviews.is_none() {
-                    match self
-                        .get_pull_request_reviews(owner, repo, pull_request.number)
-                        .await
-                    {
-                        Ok(r) => pull_request.reviews = Some(r),
-                        Err(e) => error!("Error refetching pull request reviews: {}", e),
-                    };
-                }
-            }
-
-            pull_requests.extend(next_prs.into_iter());
-            page += 1;
-        }
-
-        Ok(pull_requests)
+        let paging_url = &format!(
+            "repos/{}/{}/commits/{}/pulls?head={}&per_page=100",
+            owner,
+            repo,
+            commit,
+            head.unwrap_or(""),
+        );
+        let err_fmt = &format!(
+            "Error looking up PRs for commit: {}/{}/{}",
+            owner, repo, commit
+        );
+        return self
+            .do_get_pull_requests(owner, repo, head, paging_url, err_fmt)
+            .await;
     }
 
     async fn create_pull_request(

--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -26,6 +26,13 @@ pub trait Session: Send + Sync {
         state: Option<&str>,
         head: Option<&str>,
     ) -> Result<Vec<PullRequest>>;
+    async fn get_pull_requests_by_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        commit: &str,
+        head: Option<&str>,
+    ) -> Result<Vec<PullRequest>>;
 
     async fn create_pull_request(
         &self,
@@ -438,6 +445,67 @@ impl Session for GithubSession {
                 ))
                 .await
                 .map_err(|e| format_err!("Error looking up PRs: {}/{}: {}", owner, repo, e))
+                .map(|prs| {
+                    prs.into_iter()
+                        .filter(|p| {
+                            if let Some(head) = head {
+                                p.head.ref_name == head || p.head.sha == head
+                            } else {
+                                true
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                }) {
+                Ok(r) => r,
+                Err(e) => return Err(e),
+            };
+
+            if next_prs.is_empty() {
+                break;
+            }
+
+            for pull_request in &mut next_prs {
+                if pull_request.reviews.is_none() {
+                    match self
+                        .get_pull_request_reviews(owner, repo, pull_request.number)
+                        .await
+                    {
+                        Ok(r) => pull_request.reviews = Some(r),
+                        Err(e) => error!("Error refetching pull request reviews: {}", e),
+                    };
+                }
+            }
+
+            pull_requests.extend(next_prs.into_iter());
+            page += 1;
+        }
+
+        Ok(pull_requests)
+    }
+
+    async fn get_pull_requests_by_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        commit: &str,
+        head: Option<&str>,
+    ) -> Result<Vec<PullRequest>> {
+        let mut pull_requests = vec![];
+        let mut page = 1;
+
+        loop {
+            let mut next_prs: Vec<PullRequest> = match self
+                .client
+                .get::<Vec<PullRequest>>(&format!(
+                    "repos/{}/{}/commits/{}/pulls?head={}&per_page=100&page={}",
+                    owner,
+                    repo,
+                    commit,
+                    head.unwrap_or(""),
+                    page
+                ))
+                .await
+                .map_err(|e| format_err!("Error looking up PRs for commit: {}/{}/{}: {}", owner, repo, commit, e))
                 .map(|prs| {
                     prs.into_iter()
                         .filter(|p| {

--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -154,7 +154,7 @@ impl Repo {
             None => return Err(format_err!("No path segments in URL")),
         };
         if segments.len() != 2 {
-            return Err(format_err!("Expectd only two path segments!"));
+            return Err(format_err!("Expected only two path segments!"));
         }
 
         let user = segments[0];

--- a/lib/src/repos.rs
+++ b/lib/src/repos.rs
@@ -177,7 +177,7 @@ impl RepoConfig {
                     force_push_notify = ?3,
                     use_threads = ?4,
                     release_branch_prefix = ?5
-               WHERE id = ?5"#,
+               WHERE id = ?6"#,
             &[
                 &repo.repo,
                 &repo.channel,

--- a/lib/src/repos.rs
+++ b/lib/src/repos.rs
@@ -18,6 +18,7 @@ pub struct RepoInfo {
     // slack channel to send all messages to
     pub channel: String,
     pub force_push_notify: bool,
+    pub use_threads: bool,
     // A list of jira projects to be respected in processing.
     #[serde(default)]
     pub jira_config: Vec<RepoJiraConfig>,
@@ -61,6 +62,7 @@ impl RepoInfo {
             repo: repo.into(),
             channel: channel.into(),
             force_push_notify: false,
+            use_threads: false,
             jira_config: vec![],
             release_branch_prefix: String::new(),
         }
@@ -69,6 +71,12 @@ impl RepoInfo {
     pub fn with_force_push(self, value: bool) -> RepoInfo {
         let mut info = self;
         info.force_push_notify = value;
+        info
+    }
+
+    pub fn with_use_threads(self, value: bool) -> RepoInfo {
+        let mut info = self;
+        info.use_threads = value;
         info
     }
 
@@ -133,12 +141,13 @@ impl RepoConfig {
         let tx = conn.transaction()?;
 
         tx.execute(
-            r#"INSERT INTO repos (repo, channel, force_push_notify, release_branch_prefix)
-               VALUES (?1, ?2, ?3, ?4)"#,
+            r#"INSERT INTO repos (repo, channel, force_push_notify, use_threads, release_branch_prefix)
+               VALUES (?1, ?2, ?3, ?4, ?5)"#,
             &[
                 &repo.repo,
                 &repo.channel,
                 &db::to_tinyint(repo.force_push_notify) as &dyn ToSql,
+                &db::to_tinyint(repo.use_threads) as &dyn ToSql,
                 &repo.release_branch_prefix,
             ],
         )
@@ -166,12 +175,14 @@ impl RepoConfig {
                 SET repo = ?1,
                     channel = ?2,
                     force_push_notify = ?3,
-                    release_branch_prefix = ?4
+                    use_threads = ?4,
+                    release_branch_prefix = ?5
                WHERE id = ?5"#,
             &[
                 &repo.repo,
                 &repo.channel,
                 &db::to_tinyint(repo.force_push_notify) as &dyn ToSql,
+                &db::to_tinyint(repo.use_threads) as &dyn ToSql,
                 &repo.release_branch_prefix,
                 &id,
             ],
@@ -360,6 +371,7 @@ impl RepoConfig {
             repo: cols.get(row, "repo")?,
             channel: cols.get(row, "channel")?,
             force_push_notify: db::to_bool(cols.get(row, "force_push_notify")?),
+            use_threads: db::to_bool(cols.get(row, "use_threads")?),
             jira_config,
             release_branch_prefix: cols.get(row, "release_branch_prefix")?,
         })

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -353,6 +353,7 @@ app.controller('ReposController', function($rootScope, $scope, sessionHttp, noti
   $scope.addRepo = function() {
     $scope.theRepo = {
       force_push_notify: true,
+      use_threads: false,
       jira_config: [],
     };
     $('#add-repo-modal').modal('show');

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -353,7 +353,7 @@ app.controller('ReposController', function($rootScope, $scope, sessionHttp, noti
   $scope.addRepo = function() {
     $scope.theRepo = {
       force_push_notify: true,
-      use_threads: false,
+      use_threads: true,
       jira_config: [],
     };
     $('#add-repo-modal').modal('show');

--- a/octobot/src/assets/repos.html
+++ b/octobot/src/assets/repos.html
@@ -1,4 +1,4 @@
-<h3>Repos</h3>
+<h3 xmlns="http://www.w3.org/1999/html">Repos</h3>
   <div style="margin: 10px; float: right">
     <button type="button" class="btn btn-sm btn-primary" ng-click="addRepo()">Add repo</button>
   </div>
@@ -45,7 +45,12 @@
           <h4>Git</h4>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="theRepo.force_push_notify"> Force-push notification
+              <input type="checkbox" ng-model="theRepo.force_push_notify"/> Force-push notification
+            </label>
+          </div>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="theRepo.use_threads"/> Use threads for PRs
             </label>
           </div>
           <div class="form-group">

--- a/octobot/src/assets/repos.html
+++ b/octobot/src/assets/repos.html
@@ -50,7 +50,7 @@
           </div>
           <div class="checkbox">
             <label>
-              <input type="checkbox" ng-model="theRepo.use_threads"/> Use threads for PRs
+              <input type="checkbox" ng-model="theRepo.use_threads"/> Use slack threads
             </label>
           </div>
           <div class="form-group">

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -510,6 +510,7 @@ impl GithubEventHandler {
                             &self.repository,
                             branch_name,
                             &commits,
+                            pull_request.html_url.as_str(),
                         ),
 
                         NotifyMode::All => self.messenger.send_to_all(
@@ -521,6 +522,7 @@ impl GithubEventHandler {
                             &self.all_participants(&pull_request, &commits),
                             branch_name,
                             &commits,
+                            pull_request.html_url.as_str(),
                         ),
 
                         NotifyMode::None => (),
@@ -670,6 +672,7 @@ impl GithubEventHandler {
                         &participants,
                         branch_name,
                         &commits,
+                        pull_request.html_url.as_str(),
                     );
                 }
             }
@@ -722,6 +725,7 @@ impl GithubEventHandler {
             &participants,
             branch_name,
             commits,
+            pull_request.html_url()
         );
     }
 
@@ -761,6 +765,7 @@ impl GithubEventHandler {
                         &[],
                         branch_name,
                         &commits,
+                        &commit_url,
                     );
                 }
             }
@@ -894,6 +899,7 @@ impl GithubEventHandler {
                             &self.all_participants(&pull_request, &commits),
                             &branch_name,
                             &commits,
+                            pull_request.html_url.as_str(),
                         );
 
                         if self.data.forced()

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -1057,10 +1057,10 @@ impl GithubEventHandler {
     }
 
     fn build_thread_guid(&self, repo: Repo, number: u32) -> String {
-        return format!("{}/{}/{}", repo.owner.login(), repo.name, number);
+        format!("{}/{}/{}", repo.owner.login(), repo.name, number)
     }
 
     fn build_thread_guid_for_pr(&self, pr: &PullRequest) -> String {
-        return self.build_thread_guid(pr.base.repo.clone(), pr.number);
+        self.build_thread_guid(pr.base.repo.clone(), pr.number)
     }
 }

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -513,8 +513,7 @@ impl GithubEventHandler {
                             vec![pull_request.html_url.to_string()],
                         ),
 
-                        NotifyMode::All => self
-                            .messenger.send_to_all(
+                        NotifyMode::All => self.messenger.send_to_all(
                             &msg,
                             &attachments,
                             &pull_request.user,
@@ -770,15 +769,18 @@ impl GithubEventHandler {
                         Ok(p) => p,
                         Err(e) => {
                             error!(
-                            "Error looking up PR for '{}' ({}): {}",
-                            branch_name,
-                            self.data.after(),
-                            e
-                        );
+                                "Error looking up PR for '{}' ({}): {}",
+                                branch_name,
+                                self.data.after(),
+                                e
+                            );
                             return (StatusCode::OK, "push [no PR]".into());
                         }
                     };
-                    let thread_urls = commit_prs.into_iter().map(|pr| pr.clone().html_url).collect();
+                    let thread_urls = commit_prs
+                        .into_iter()
+                        .map(|pr| pr.clone().html_url)
+                        .collect();
                     self.messenger.send_to_all(
                         &msg,
                         &attachments,

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -777,10 +777,7 @@ impl GithubEventHandler {
                             return (StatusCode::OK, "push [no PR]".into());
                         }
                     };
-                    let thread_urls = commit_prs
-                        .into_iter()
-                        .map(|pr| pr.clone().html_url)
-                        .collect();
+                    let thread_urls = commit_prs.into_iter().map(|pr| pr.html_url).collect();
                     self.messenger.send_to_all(
                         &msg,
                         &attachments,

--- a/octobot/tests/git_test.rs
+++ b/octobot/tests/git_test.rs
@@ -361,7 +361,7 @@ fn test_get_commit_desc() {
     assert_eq!(
         (
             "I have a subject".into(),
-            "And I forgot to skip a line".into()
+            "And I forgot to skip a line".into(),
         ),
         git.git.get_commit_desc("HEAD").unwrap()
     );

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -1549,7 +1549,7 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, repo_msg),
             &attach,
-            Some("some-user/some-repo/32".to_string()),
+            Some("some-user/custom-branches-repo/32".to_string()),
             false,
         ),
         slack::req(

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -337,7 +337,8 @@ async fn test_commit_comment_with_path() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            Some(pr1.clone().html_url),
+            Some("some-user/some-repo/32".to_string()),
+        false,
         ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
@@ -346,7 +347,8 @@ async fn test_commit_comment_with_path() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            Some(pr2.clone().html_url),
+            Some("some-user/some-repo/99".to_string()),
+        false,
         ),
     ]);
 
@@ -383,7 +385,8 @@ async fn test_commit_comment_with_path_that_is_included_in_multiple_prs() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            Some(pr.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+        false,
         )
     ]);
 
@@ -421,6 +424,7 @@ async fn test_commit_comment_no_path() {
                 .title_link("http://the-comment")
                 .build()],
             None,
+        false,
         )
     ]);
 
@@ -462,20 +466,29 @@ async fn test_issue_comment() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.issue.clone().unwrap().html_url),
+            Some("some-user/some-repo/5".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -512,26 +525,36 @@ async fn test_pull_request_comment() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -567,26 +590,36 @@ async fn test_pull_request_review_commented() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -667,26 +700,36 @@ async fn test_pull_request_review_approved() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -723,26 +766,36 @@ async fn test_pull_request_review_changes_requested() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -771,7 +824,8 @@ async fn test_pull_request_opened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        Some(test.handler.data.pull_request.clone().unwrap().html_url),
+        Some("some-user/some-repo/32".to_string()),
+        true,
     )]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -798,26 +852,36 @@ async fn test_pull_request_closed() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -844,7 +908,8 @@ async fn test_pull_request_reopened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        Some(test.handler.data.pull_request.clone().unwrap().html_url),
+        Some("some-user/some-repo/32".to_string()),
+        false,
     )]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -873,26 +938,36 @@ async fn test_pull_request_ready_for_review() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -957,27 +1032,43 @@ async fn test_pull_request_assigned() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("assign2"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1004,7 +1095,8 @@ async fn test_pull_request_unassigned() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        Some(test.handler.data.pull_request.clone().unwrap().html_url),
+        Some("some-user/some-repo/32".to_string()),
+        false,
     )]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1034,32 +1126,43 @@ async fn test_pull_request_review_requested() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("smith.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1090,20 +1193,29 @@ async fn test_pull_request_review_no_username() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1178,43 +1290,50 @@ async fn test_pull_request_merged_error_getting_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg1, REPO_MSG),
             &attach1,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg1,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("assign1"),
             msg1,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg1,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg1,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg2, REPO_MSG),
             &attach2,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg2,
             &attach2,
             None,
+            false,
         ),
     ]);
 
@@ -1248,26 +1367,36 @@ async fn test_pull_request_merged_no_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1311,26 +1440,36 @@ async fn test_pull_request_merged_backport_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1410,26 +1549,36 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, repo_msg),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1577,7 +1726,6 @@ async fn test_push_with_pr() {
     pr2.assignees = vec![User::new("assign2")];
     pr2.requested_reviewers = None;
 
-    let pr_url = pr1.clone().html_url;
     // no jira references here: should fail
     expect_jira_ref_fail_pr(&test.github, &pr1, &some_commits());
     expect_jira_ref_fail_pr(&test.github, &pr2, &some_commits());
@@ -1618,45 +1766,64 @@ async fn test_push_with_pr() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach1,
-            Some(pr_url.clone()),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach1,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach1, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach1,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach1,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach2,
-            Some(pr_url),
+            Some("some-user/some-repo/99".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach2,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach2, None),
+        slack::req(
+            SlackRecipient::user_mention("assign2"),
+            msg,
+            &attach2,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach2,
             None,
+            false,
         ),
     ]);
 
@@ -1699,26 +1866,36 @@ async fn test_push_force_notify() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            Some(pr.clone().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1796,19 +1973,28 @@ async fn test_push_force_notify_ignored() {
             msg,
             &attach,
             None,
+            false,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
             msg,
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
             msg,
             &attach,
             None,
+            false,
         ),
     ]);
 
@@ -1909,7 +2095,8 @@ async fn test_jira_pull_request_opened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        Some(test.handler.data.pull_request.clone().unwrap().html_url),
+        Some("some-user/some-repo/32".to_string()),
+        true,
     )]);
 
     expect_jira_ref_pass_pr(
@@ -1969,7 +2156,8 @@ async fn test_jira_pull_request_opened_too_many_commits() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("Pull Request opened by the.pr.owner {}", REPO_MSG),
             &attach,
-            Some(test.handler.data.pull_request.clone().unwrap().html_url),
+            Some("some-user/some-repo/32".to_string()),
+            true,
         ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
@@ -1979,12 +2167,14 @@ async fn test_jira_pull_request_opened_too_many_commits() {
             ),
             &attach,
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             &"Too many commits on Pull Request #32. Ignoring JIRAs.".to_string(),
             &attach,
             None,
+            false,
         ),
     ]);
 

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -11,8 +11,8 @@ use mocks::mock_worker::LockedMockWorker;
 use octobot::server::github_handler::GithubEventHandler;
 use octobot_lib::config::{Config, JiraConfig};
 use octobot_lib::config_db::ConfigDatabase;
-use octobot_lib::github::*;
 use octobot_lib::github::api::Session;
+use octobot_lib::github::*;
 use octobot_lib::jira;
 use octobot_lib::repos;
 use octobot_lib::slack::SlackRecipient;
@@ -322,8 +322,13 @@ async fn test_commit_comment_with_path() {
     pr2.number = 99;
     pr2.assignees = vec![User::new("assign2")];
     pr2.requested_reviewers = None;
-    test.github
-        .mock_get_pull_requests_by_commit("some-user", "some-repo", "abcdef0", None, Ok(vec![pr1.clone(), pr2.clone()]));
+    test.github.mock_get_pull_requests_by_commit(
+        "some-user",
+        "some-repo",
+        "abcdef0",
+        None,
+        Ok(vec![pr1.clone(), pr2.clone()]),
+    );
     test.slack.expect(vec![
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
@@ -342,7 +347,7 @@ async fn test_commit_comment_with_path() {
                 .title_link("http://the-comment")
                 .build()],
             Some(pr2.clone().html_url),
-        )
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -363,8 +368,13 @@ async fn test_commit_comment_with_path_that_is_included_in_multiple_prs() {
     });
     test.handler.data.sender = User::new("joe-reviewer");
     let pr = some_pr();
-    test.github
-        .mock_get_pull_requests_by_commit("some-user", "some-repo", "abcdef0", None, Ok(vec![pr.clone().unwrap()]));
+    test.github.mock_get_pull_requests_by_commit(
+        "some-user",
+        "some-repo",
+        "abcdef0",
+        None,
+        Ok(vec![pr.clone().unwrap()]),
+    );
     test.slack.expect(vec![
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
@@ -395,8 +405,13 @@ async fn test_commit_comment_no_path() {
     });
     test.handler.data.sender = User::new("joe-reviewer");
 
-    test.github
-        .mock_get_pull_requests_by_commit("some-user", "some-repo", "abcdef0", None, Ok(vec![]));
+    test.github.mock_get_pull_requests_by_commit(
+        "some-user",
+        "some-repo",
+        "abcdef0",
+        None,
+        Ok(vec![]),
+    );
     test.slack.expect(vec![
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
@@ -449,7 +464,12 @@ async fn test_issue_comment() {
             &attach,
             Some(test.handler.data.issue.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
@@ -494,9 +514,19 @@ async fn test_pull_request_comment() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
@@ -539,9 +569,19 @@ async fn test_pull_request_review_commented() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
@@ -629,9 +669,19 @@ async fn test_pull_request_review_approved() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
@@ -675,9 +725,19 @@ async fn test_pull_request_review_changes_requested() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
@@ -740,10 +800,25 @@ async fn test_pull_request_closed() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -800,10 +875,25 @@ async fn test_pull_request_ready_for_review() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -869,11 +959,26 @@ async fn test_pull_request_assigned() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
         slack::req(SlackRecipient::user_mention("assign2"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -931,11 +1036,31 @@ async fn test_pull_request_review_requested() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("smith.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("smith.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -967,9 +1092,19 @@ async fn test_pull_request_review_no_username() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1045,17 +1180,42 @@ async fn test_pull_request_merged_error_getting_labels() {
             &attach1,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg1, &attach1, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg1, &attach1, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg1, &attach1, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg1, &attach1, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg1,
+            &attach1,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            msg1,
+            &attach1,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg1,
+            &attach1,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg1,
+            &attach1,
+            None,
+        ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg2, REPO_MSG),
             &attach2,
             None,
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg2, &attach2, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg2,
+            &attach2,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1090,10 +1250,25 @@ async fn test_pull_request_merged_no_labels() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1138,10 +1313,25 @@ async fn test_pull_request_merged_backport_labels() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     test.expect_will_merge_branches(
@@ -1222,10 +1412,25 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
             &attach,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     test.expect_will_merge_branches(
@@ -1415,19 +1620,44 @@ async fn test_push_with_pr() {
             &attach1,
             Some(pr_url.clone()),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach1, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach1,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach1, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach1, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach1, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach1,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach1,
+            None,
+        ),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach2,
             Some(pr_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach2, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach2,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign2"), msg, &attach2, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach2, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach2,
+            None,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1471,10 +1701,25 @@ async fn test_push_force_notify() {
             &attach,
             Some(pr.clone().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     test.expect_will_force_push_notify(&pr, "abcdef0000", "1111abcdef");
@@ -1546,10 +1791,25 @@ async fn test_push_force_notify_ignored() {
         .title_link("http://the-pr")
         .build()];
     test.slack.expect(vec![
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+        ),
         slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(
+            SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+        ),
     ]);
 
     // Note: no expectations here.

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -332,7 +332,6 @@ async fn test_commit_comment_with_path() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            true,
             Some(pr1.clone().html_url),
         ),
         slack::req(
@@ -342,7 +341,6 @@ async fn test_commit_comment_with_path() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            true,
             Some(pr2.clone().html_url),
         )
     ]);
@@ -375,7 +373,6 @@ async fn test_commit_comment_with_path_that_is_included_in_multiple_prs() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            true,
             Some(pr.clone().unwrap().html_url),
         )
     ]);
@@ -408,7 +405,6 @@ async fn test_commit_comment_no_path() {
                 .title("joe.reviewer said:")
                 .title_link("http://the-comment")
                 .build()],
-            false,
             None,
         )
     ]);
@@ -451,16 +447,14 @@ async fn test_issue_comment() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.issue.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
-            false,
             None,
         ),
     ]);
@@ -498,17 +492,15 @@ async fn test_pull_request_comment() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
-            false,
             None,
         ),
     ]);
@@ -545,17 +537,15 @@ async fn test_pull_request_review_commented() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
-            false,
             None,
         ),
     ]);
@@ -637,17 +627,15 @@ async fn test_pull_request_review_approved() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
-            false,
             None,
         ),
     ]);
@@ -685,17 +673,15 @@ async fn test_pull_request_review_changes_requested() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
             msg,
             &attach,
-            false,
             None,
         ),
     ]);
@@ -725,7 +711,6 @@ async fn test_pull_request_opened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        true,
         Some(test.handler.data.pull_request.clone().unwrap().html_url),
     )]);
 
@@ -753,13 +738,12 @@ async fn test_pull_request_closed() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -785,7 +769,6 @@ async fn test_pull_request_reopened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        true,
         Some(test.handler.data.pull_request.clone().unwrap().html_url),
     )]);
 
@@ -815,13 +798,12 @@ async fn test_pull_request_ready_for_review() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -885,14 +867,13 @@ async fn test_pull_request_assigned() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -918,7 +899,6 @@ async fn test_pull_request_unassigned() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        true,
         Some(test.handler.data.pull_request.clone().unwrap().html_url),
     )]);
 
@@ -949,14 +929,13 @@ async fn test_pull_request_review_requested() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("smith.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("smith.reviewer"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -986,12 +965,11 @@ async fn test_pull_request_review_no_username() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1065,21 +1043,19 @@ async fn test_pull_request_merged_error_getting_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg1, REPO_MSG),
             &attach1,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg1, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg1, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg1, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg1, &attach1, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg1, &attach1, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg1, &attach1, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg1, &attach1, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg1, &attach1, None),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg2, REPO_MSG),
             &attach2,
-            false,
             None,
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg2, &attach2, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg2, &attach2, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1112,13 +1088,12 @@ async fn test_pull_request_merged_no_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1161,13 +1136,12 @@ async fn test_pull_request_merged_backport_labels() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     test.expect_will_merge_branches(
@@ -1246,13 +1220,12 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, repo_msg),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     test.expect_will_merge_branches(
@@ -1440,23 +1413,21 @@ async fn test_push_with_pr() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach1,
-            true,
             Some(pr_url.clone()),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach1, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach1, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach1, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach1, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach1, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach1, None),
         slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach2,
-            true,
             Some(pr_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach2, false, None),
-        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach2, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach2, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach2, None),
+        slack::req(SlackRecipient::user_mention("assign2"), msg, &attach2, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach2, None),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1498,13 +1469,12 @@ async fn test_push_force_notify() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach,
-            true,
             Some(pr.clone().html_url),
         ),
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     test.expect_will_force_push_notify(&pr, "abcdef0000", "1111abcdef");
@@ -1576,10 +1546,10 @@ async fn test_push_force_notify_ignored() {
         .title_link("http://the-pr")
         .build()];
     test.slack.expect(vec![
-        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, false, None),
-        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, false, None),
+        slack::req(SlackRecipient::user_mention("the.pr.owner"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("assign1"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("bob.author"), msg, &attach, None),
+        slack::req(SlackRecipient::user_mention("joe.reviewer"), msg, &attach, None),
     ]);
 
     // Note: no expectations here.
@@ -1679,7 +1649,6 @@ async fn test_jira_pull_request_opened() {
         SlackRecipient::by_name("the-reviews-channel"),
         &format!("{} {}", msg, REPO_MSG),
         &attach,
-        true,
         Some(test.handler.data.pull_request.clone().unwrap().html_url),
     )]);
 
@@ -1740,7 +1709,6 @@ async fn test_jira_pull_request_opened_too_many_commits() {
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("Pull Request opened by the.pr.owner {}", REPO_MSG),
             &attach,
-            true,
             Some(test.handler.data.pull_request.clone().unwrap().html_url),
         ),
         slack::req(
@@ -1750,14 +1718,12 @@ async fn test_jira_pull_request_opened_too_many_commits() {
                 REPO_MSG
             ),
             &attach,
-            false,
             None,
         ),
         slack::req(
             SlackRecipient::user_mention("the.pr.owner"),
             &"Too many commits on Pull Request #32. Ignoring JIRAs.".to_string(),
             &attach,
-            false,
             None,
         ),
     ]);

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -51,7 +51,7 @@ fn test_sends_to_owner() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 
@@ -77,7 +77,7 @@ fn test_sends_to_mapped_usernames() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 
@@ -118,7 +118,7 @@ fn test_sends_to_owner_with_channel() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 
@@ -192,7 +192,7 @@ fn test_does_not_send_to_event_sender() {
         &[github::User::new("userA"), github::User::new("userB")],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 
@@ -229,7 +229,7 @@ fn test_sends_only_once() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 
@@ -262,6 +262,6 @@ fn test_peace_and_quiet() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -162,7 +162,7 @@ fn test_sends_to_assignees() {
         &[github::User::new("assign1"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
+        vec!["some-user/some-repo/1".to_string()],
     );
 }
 

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -38,6 +38,8 @@ fn test_sends_to_owner() {
         SlackRecipient::user_mention("the.owner"),
         "hello there",
         &[],
+        false,
+        None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
     messenger.send_to_all(
@@ -49,6 +51,7 @@ fn test_sends_to_owner() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -60,6 +63,8 @@ fn test_sends_to_mapped_usernames() {
         SlackRecipient::user_mention("the.owner"),
         "hello there",
         &[],
+        false,
+        None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
 
@@ -72,6 +77,7 @@ fn test_sends_to_mapped_usernames() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -90,11 +96,15 @@ fn test_sends_to_owner_with_channel() {
             SlackRecipient::by_name("the-review-channel"),
             "hello there (<http://git.foo.com/the-owner/the-repo|the-owner/the-repo>)",
             &[],
+            false,
+            Some("http://the-github-host/some-user/some-repo/pulls/1".to_string()),
         ),
         slack::req(
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
+            false,
+            None,
         ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -108,6 +118,7 @@ fn test_sends_to_owner_with_channel() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -123,9 +134,11 @@ fn test_sends_to_assignees() {
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
+            false,
+            None,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), "hello there", &[]),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[]),
+        slack::req(SlackRecipient::user_mention("assign1"), "hello there", &[], false, None),
+        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], false, None),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     messenger.send_to_all(
@@ -137,6 +150,7 @@ fn test_sends_to_assignees() {
         &[github::User::new("assign1"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -151,6 +165,8 @@ fn test_does_not_send_to_event_sender() {
         SlackRecipient::user_mention("userB"),
         "hello there",
         &[],
+        false,
+        None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
     // Note: 'userA' is owner, sender, and assignee. (i.e. commented on a PR that he opened and is
@@ -164,6 +180,7 @@ fn test_does_not_send_to_event_sender() {
         &[github::User::new("userA"), github::User::new("userB")],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -178,8 +195,10 @@ fn test_sends_only_once() {
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
+            false,
+            None,
         ),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[]),
+        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], false, None),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     // Note: 'the-owner' is also assigned. Should only receive one slackbot message though.
@@ -192,6 +211,7 @@ fn test_sends_only_once() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }
 
@@ -210,6 +230,8 @@ fn test_peace_and_quiet() {
         SlackRecipient::user_mention("assign2"),
         "hello there",
         &[],
+        false,
+        None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
 
@@ -222,5 +244,6 @@ fn test_peace_and_quiet() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
+        "http://the-github-host/some-user/some-repo/pulls/1",
     );
 }

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -38,7 +38,6 @@ fn test_sends_to_owner() {
         SlackRecipient::user_mention("the.owner"),
         "hello there",
         &[],
-        false,
         None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -63,7 +62,6 @@ fn test_sends_to_mapped_usernames() {
         SlackRecipient::user_mention("the.owner"),
         "hello there",
         &[],
-        false,
         None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -96,14 +94,12 @@ fn test_sends_to_owner_with_channel() {
             SlackRecipient::by_name("the-review-channel"),
             "hello there (<http://git.foo.com/the-owner/the-repo|the-owner/the-repo>)",
             &[],
-            false,
             None,
         ),
         slack::req(
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
-            false,
             None,
         ),
     ]);
@@ -134,11 +130,10 @@ fn test_sends_to_assignees() {
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
-            false,
             None,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), "hello there", &[], false, None),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], false, None),
+        slack::req(SlackRecipient::user_mention("assign1"), "hello there", &[], None),
+        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], None),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     messenger.send_to_all(
@@ -165,7 +160,6 @@ fn test_does_not_send_to_event_sender() {
         SlackRecipient::user_mention("userB"),
         "hello there",
         &[],
-        false,
         None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -195,10 +189,9 @@ fn test_sends_only_once() {
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
-            false,
             None,
         ),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], false, None),
+        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], None),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     // Note: 'the-owner' is also assigned. Should only receive one slackbot message though.
@@ -230,7 +223,6 @@ fn test_peace_and_quiet() {
         SlackRecipient::user_mention("assign2"),
         "hello there",
         &[],
-        false,
         None,
     )]);
     let messenger = messenger::new(config, slack.new_sender());

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -51,7 +51,7 @@ fn test_sends_to_owner() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -77,7 +77,7 @@ fn test_sends_to_mapped_usernames() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -97,7 +97,7 @@ fn test_sends_to_owner_with_channel() {
             "hello there (<http://git.foo.com/the-owner/the-repo|the-owner/the-repo>)",
             &[],
             false,
-            Some("http://the-github-host/some-user/some-repo/pulls/1".to_string()),
+            None,
         ),
         slack::req(
             SlackRecipient::user_mention("the.owner"),
@@ -118,7 +118,7 @@ fn test_sends_to_owner_with_channel() {
         &[],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -150,7 +150,7 @@ fn test_sends_to_assignees() {
         &[github::User::new("assign1"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -180,7 +180,7 @@ fn test_does_not_send_to_event_sender() {
         &[github::User::new("userA"), github::User::new("userB")],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -211,7 +211,7 @@ fn test_sends_only_once() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }
 
@@ -244,6 +244,6 @@ fn test_peace_and_quiet() {
         &[github::User::new("the-owner"), github::User::new("assign2")],
         "",
         &Vec::<github::Commit>::new(),
-        "http://the-github-host/some-user/some-repo/pulls/1",
+        vec!["http://the-github-host/some-user/some-repo/pulls/1".to_string()],
     );
 }

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -39,6 +39,7 @@ fn test_sends_to_owner() {
         "hello there",
         &[],
         None,
+        false,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
     messenger.send_to_all(
@@ -63,6 +64,7 @@ fn test_sends_to_mapped_usernames() {
         "hello there",
         &[],
         None,
+        false,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
 
@@ -95,12 +97,14 @@ fn test_sends_to_owner_with_channel() {
             "hello there (<http://git.foo.com/the-owner/the-repo|the-owner/the-repo>)",
             &[],
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("the.owner"),
             "hello there",
             &[],
             None,
+            false,
         ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -131,18 +135,21 @@ fn test_sends_to_assignees() {
             "hello there",
             &[],
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("assign1"),
             "hello there",
             &[],
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("assign2"),
             "hello there",
             &[],
             None,
+            false,
         ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -171,6 +178,7 @@ fn test_does_not_send_to_event_sender() {
         "hello there",
         &[],
         None,
+        false,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
     // Note: 'userA' is owner, sender, and assignee. (i.e. commented on a PR that he opened and is
@@ -200,12 +208,14 @@ fn test_sends_only_once() {
             "hello there",
             &[],
             None,
+            false,
         ),
         slack::req(
             SlackRecipient::user_mention("assign2"),
             "hello there",
             &[],
             None,
+            false,
         ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
@@ -239,6 +249,7 @@ fn test_peace_and_quiet() {
         "hello there",
         &[],
         None,
+        false,
     )]);
     let messenger = messenger::new(config, slack.new_sender());
 

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -132,8 +132,18 @@ fn test_sends_to_assignees() {
             &[],
             None,
         ),
-        slack::req(SlackRecipient::user_mention("assign1"), "hello there", &[], None),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], None),
+        slack::req(
+            SlackRecipient::user_mention("assign1"),
+            "hello there",
+            &[],
+            None,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("assign2"),
+            "hello there",
+            &[],
+            None,
+        ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     messenger.send_to_all(
@@ -191,7 +201,12 @@ fn test_sends_only_once() {
             &[],
             None,
         ),
-        slack::req(SlackRecipient::user_mention("assign2"), "hello there", &[], None),
+        slack::req(
+            SlackRecipient::user_mention("assign2"),
+            "hello there",
+            &[],
+            None,
+        ),
     ]);
     let messenger = messenger::new(config, slack.new_sender());
     // Note: 'the-owner' is also assigned. Should only receive one slackbot message though.

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -198,7 +198,10 @@ impl Session for MockGithub {
         head: Option<&str>,
     ) -> Result<Vec<PullRequest>> {
         let mut calls = self.get_prs_by_commit_calls.lock().unwrap();
-        assert!(calls.len() > 0, "Unexpected call to get_pull_requests_by_commit");
+        assert!(
+            calls.len() > 0,
+            "Unexpected call to get_pull_requests_by_commit"
+        );
         let call = calls.remove(0);
         assert_eq!(call.args[0], owner);
         assert_eq!(call.args[1], repo);
@@ -502,10 +505,13 @@ impl MockGithub {
         head: Option<&str>,
         ret: Result<Vec<PullRequest>>,
     ) {
-        self.get_prs_by_commit_calls.lock().unwrap().push(MockCall::new(
-            ret,
-            vec![owner, repo, commit, "", head.unwrap_or("")],
-        ));
+        self.get_prs_by_commit_calls
+            .lock()
+            .unwrap()
+            .push(MockCall::new(
+                ret,
+                vec![owner, repo, commit, "", head.unwrap_or("")],
+            ));
     }
 
     pub fn mock_create_pull_request(

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -581,7 +581,9 @@ async fn test_pr_merge_backport_failure() {
                 .title("Source PR: #123: \"The Title\"")
                 .title_link("")
                 .color("danger")
-                .build()]
+                .build()],
+            false,
+            Some("".to_string()),
         )
     ]);
 

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -582,7 +582,6 @@ async fn test_pr_merge_backport_failure() {
                 .title_link("")
                 .color("danger")
                 .build()],
-            false,
             None,
         )
     ]);

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -583,6 +583,7 @@ async fn test_pr_merge_backport_failure() {
                 .color("danger")
                 .build()],
             None,
+            false,
         )
     ]);
 

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -583,7 +583,7 @@ async fn test_pr_merge_backport_failure() {
                 .color("danger")
                 .build()],
             false,
-            Some("".to_string()),
+            None,
         )
     ]);
 

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -12,6 +12,8 @@ pub mod migrate_slack;
 pub mod pr_merge;
 pub mod repo_version;
 pub mod slack;
+mod slack_db;
+mod slack_db_migrations;
 pub mod util;
 pub mod webhook_db;
 mod webhook_db_migrations;

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -83,8 +83,7 @@ impl Messenger {
     ) {
         // We could look at the thread_url to see if threads have been used in the past, but that
         // wouldn't respect the users' choice if they change the setting later.
-        let use_threads =
-            self.config.repos().notify_use_threads(repo) && !thread_urls.is_empty();
+        let use_threads = self.config.repos().notify_use_threads(repo) && !thread_urls.is_empty();
 
         for channel in self.config.repos().lookup_channels(repo, branch, commits) {
             let channel_msg = format!(

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -61,7 +61,14 @@ impl Messenger {
         branch: &str,
         commits: &[T],
     ) {
-        self.send_to_channel(msg, attachments, repo, branch, commits, Vec::<String>::new());
+        self.send_to_channel(
+            msg,
+            attachments,
+            repo,
+            branch,
+            commits,
+            Vec::<String>::new(),
+        );
         self.send_to_slackbots(vec![item_owner.clone()], msg, attachments);
     }
 
@@ -76,7 +83,8 @@ impl Messenger {
     ) {
         // We could look at the thread_url to see if threads have been used in the past, but that
         // wouldn't respect the users' choice if they change the setting later.
-        let use_threads = self.config.repos().notify_use_threads(repo) && !thread_urls.clone().is_empty();
+        let use_threads =
+            self.config.repos().notify_use_threads(repo) && !thread_urls.clone().is_empty();
 
         for channel in self.config.repos().lookup_channels(repo, branch, commits) {
             let channel_msg = format!(

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -84,7 +84,7 @@ impl Messenger {
         // We could look at the thread_url to see if threads have been used in the past, but that
         // wouldn't respect the users' choice if they change the setting later.
         let use_threads =
-            self.config.repos().notify_use_threads(repo) && !thread_urls.clone().is_empty();
+            self.config.repos().notify_use_threads(repo) && !thread_urls.is_empty();
 
         for channel in self.config.repos().lookup_channels(repo, branch, commits) {
             let channel_msg = format!(

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -35,7 +35,7 @@ impl Messenger {
         commits: &[T],
         thread_urls: Vec<String>,
     ) {
-        self.send_to_channel(msg, attachments, repo, branch, commits, thread_urls);
+        self.send_to_channel(msg, attachments, repo, branch, commits, thread_urls, false);
 
         let mut slackbots: Vec<github::User> = vec![item_owner.clone()];
 
@@ -68,6 +68,7 @@ impl Messenger {
             branch,
             commits,
             Vec::<String>::new(),
+            false,
         );
         self.send_to_slackbots(vec![item_owner.clone()], msg, attachments);
     }
@@ -80,6 +81,7 @@ impl Messenger {
         branch: &str,
         commits: &[T],
         thread_urls: Vec<String>,
+        init_thread: bool,
     ) {
         // We could look at the thread_url to see if threads have been used in the past, but that
         // wouldn't respect the users' choice if they change the setting later.
@@ -97,6 +99,7 @@ impl Messenger {
                     &channel_msg,
                     attachments,
                     None,
+                    init_thread,
                 ));
             } else {
                 for thread_url in &thread_urls {
@@ -105,6 +108,7 @@ impl Messenger {
                         &channel_msg,
                         attachments,
                         Some(thread_url.to_owned()),
+                        init_thread,
                     ));
                 }
             }
@@ -119,7 +123,8 @@ impl Messenger {
     ) {
         for user in users {
             if let Some(channel) = self.config.users().slack_direct_message(user.login()) {
-                self.slack.send(slack::req(channel, msg, attachments, None));
+                self.slack
+                    .send(slack::req(channel, msg, attachments, None, false));
             }
         }
     }

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -73,6 +73,7 @@ impl Messenger {
         self.send_to_slackbots(vec![item_owner.clone()], msg, attachments);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn send_to_channel<T: github::CommitLike>(
         &self,
         msg: &str,

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -89,7 +89,6 @@ impl Messenger {
                     SlackRecipient::new(&channel, &channel),
                     &channel_msg,
                     attachments,
-                    use_threads,
                     None,
                 ));
             } else {
@@ -98,7 +97,6 @@ impl Messenger {
                         SlackRecipient::new(&channel, &channel),
                         &channel_msg,
                         attachments,
-                        use_threads,
                         Some(thread_url.to_owned()),
                     ));
                 }
@@ -114,7 +112,7 @@ impl Messenger {
     ) {
         for user in users {
             if let Some(channel) = self.config.users().slack_direct_message(user.login()) {
-                self.slack.send(slack::req(channel, msg, attachments, false, None));
+                self.slack.send(slack::req(channel, msg, attachments, None));
             }
         }
     }

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -99,7 +99,7 @@ impl Messenger {
                     None,
                 ));
             } else {
-                for thread_url in thread_urls.clone() {
+                for thread_url in &thread_urls {
                     self.slack.send(slack::req(
                         SlackRecipient::new(&channel, &channel),
                         &channel_msg,

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -80,12 +80,12 @@ impl Messenger {
         repo: &github::Repo,
         branch: &str,
         commits: &[T],
-        thread_urls: Vec<String>,
-        init_thread: bool,
+        thread_guids: Vec<String>,
+        initial_thread: bool,
     ) {
-        // We could look at the thread_url to see if threads have been used in the past, but that
-        // wouldn't respect the users' choice if they change the setting later.
-        let use_threads = self.config.repos().notify_use_threads(repo) && !thread_urls.is_empty();
+        // We can use the thread_guid to see if threads have been used in the past within the
+        //  slack db, but that wouldn't respect the users' choice if they change the setting later.
+        let use_threads = self.config.repos().notify_use_threads(repo) && !thread_guids.is_empty();
 
         for channel in self.config.repos().lookup_channels(repo, branch, commits) {
             let channel_msg = format!(
@@ -99,16 +99,16 @@ impl Messenger {
                     &channel_msg,
                     attachments,
                     None,
-                    init_thread,
+                    initial_thread,
                 ));
             } else {
-                for thread_url in &thread_urls {
+                for thread_guid in &thread_guids {
                     self.slack.send(slack::req(
                         SlackRecipient::new(&channel, &channel),
                         &channel_msg,
                         attachments,
-                        Some(thread_url.to_owned()),
-                        init_thread,
+                        Some(thread_guid.to_owned()),
+                        initial_thread,
                     ));
                 }
             }

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -5,7 +5,6 @@ use crate::util;
 use crate::worker::Worker;
 use octobot_lib::config::Config;
 use octobot_lib::github;
-// use octobot_lib::github::{Repo, User};
 use octobot_lib::slack::SlackRecipient;
 
 pub struct Messenger {
@@ -33,9 +32,9 @@ impl Messenger {
         participants: &[github::User],
         branch: &str,
         commits: &[T],
-        thread_urls: Vec<String>,
+        thread_guids: Vec<String>,
     ) {
-        self.send_to_channel(msg, attachments, repo, branch, commits, thread_urls, false);
+        self.send_to_channel(msg, attachments, repo, branch, commits, thread_guids, false);
 
         let mut slackbots: Vec<github::User> = vec![item_owner.clone()];
 

--- a/ops/src/repo_version.rs
+++ b/ops/src/repo_version.rs
@@ -286,7 +286,7 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                                 &req.repo,
                                 &req.branch,
                                 &req.commits,
-                                &req.repo.html_url,
+                                vec![req.repo.html_url.to_string()], // Todo(NTD) - when does this get called???
                             );
                         } else {
                             resolved = true

--- a/ops/src/repo_version.rs
+++ b/ops/src/repo_version.rs
@@ -276,7 +276,6 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                                 .color("danger")
                                 .build();
 
-                            // let commit_url = format!("{}/commit/{}", &req.repo.html_url, req.commit_hash);
                             messenger.send_to_channel(
                                 &format!(
                                     "Error running version script for [{}]",

--- a/ops/src/repo_version.rs
+++ b/ops/src/repo_version.rs
@@ -276,6 +276,7 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                                 .color("danger")
                                 .build();
 
+                            // let commit_url = format!("{}/commit/{}", &req.repo.html_url, req.commit_hash);
                             messenger.send_to_channel(
                                 &format!(
                                     "Error running version script for [{}]",
@@ -285,6 +286,7 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                                 &req.repo,
                                 &req.branch,
                                 &req.commits,
+                                &req.repo.html_url,
                             );
                         } else {
                             resolved = true

--- a/ops/src/repo_version.rs
+++ b/ops/src/repo_version.rs
@@ -285,7 +285,8 @@ impl worker::Runner<RepoVersionRequest> for Runner {
                                 &req.repo,
                                 &req.branch,
                                 &req.commits,
-                                vec![req.repo.html_url.to_string()], // Todo(NTD) - when does this get called???
+                                vec![req.repo.html_url.to_string()],
+                                false,
                             );
                         } else {
                             resolved = true

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -131,10 +131,12 @@ impl Slack {
     ) {
         let mut parent_thread = None;
         if use_threads {
-            let res = self.lookup_previous_post(thread_url.to_string(), channel_id.to_string()).await;
+            let res = self
+                .lookup_previous_post(thread_url.to_string(), channel_id.to_string())
+                .await;
             let option = res.unwrap_or(None);
             if option.is_some() {
-                 parent_thread = option
+                parent_thread = option
             }
         }
 
@@ -257,7 +259,11 @@ impl Slack {
         Ok(resp.user)
     }
 
-    pub async fn lookup_previous_post(&self, thread_url: String, slack_channel: String) -> Result<Option<String>> {
+    pub async fn lookup_previous_post(
+        &self,
+        thread_url: String,
+        slack_channel: String,
+    ) -> Result<Option<String>> {
         #[derive(Deserialize)]
         struct SearchMatch {
             ts: Option<String>,
@@ -276,7 +282,10 @@ impl Slack {
 
         let resp: Resp = self
             .client
-            .get(&format!("/search.messages?query='in:{} from:@octobot has:link {}'&sort=timestamp", slack_channel, thread_url))
+            .get(&format!(
+                "/search.messages?query='in:{} from:@octobot has:link {}'&sort=timestamp",
+                slack_channel, thread_url
+            ))
             .await?;
 
         if !resp.ok {
@@ -290,13 +299,16 @@ impl Slack {
             );
         }
 
-        let messages = resp.messages.unwrap_or(Messages{ total: 0, matches: vec![]});
+        let messages = resp.messages.unwrap_or(Messages {
+            total: 0,
+            matches: vec![],
+        });
         if messages.total == 0 {
             return Ok(None);
         }
 
         let search_match = messages.matches.first();
-        let option = search_match.unwrap_or(&SearchMatch{ ts: None }).ts.clone();
+        let option = search_match.unwrap_or(&SearchMatch { ts: None }).ts.clone();
         Ok(option)
     }
 }
@@ -333,7 +345,12 @@ struct Runner {
     slack: Arc<Slack>,
 }
 
-pub fn req(channel: SlackRecipient, msg: &str, attachments: &[SlackAttachment], thread_url: Option<String>) -> SlackRequest {
+pub fn req(
+    channel: SlackRecipient,
+    msg: &str,
+    attachments: &[SlackAttachment],
+    thread_url: Option<String>,
+) -> SlackRequest {
     SlackRequest {
         channel,
         thread_url: thread_url.into(),

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -133,7 +133,7 @@ impl Slack {
         if use_threads {
             let res = self.lookup_previous_post(thread_url.to_string(), channel_id.to_string()).await;
             let option = res.unwrap_or(None);
-            if option != None {
+            if option.is_some() {
                  parent_thread = option
             }
         }
@@ -364,7 +364,7 @@ impl worker::Runner<SlackRequest> for Runner {
                 &req.channel.name,
                 &req.msg,
                 req.attachments,
-                req.thread_url != None,
+                req.thread_url.is_some(),
                 url.as_str(),
             )
             .await;

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -353,7 +353,7 @@ pub fn req(
 ) -> SlackRequest {
     SlackRequest {
         channel,
-        thread_url: thread_url.into(),
+        thread_url,
         msg: msg.into(),
         attachments: attachments.into(),
     }

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -132,7 +132,7 @@ impl Slack {
         let mut parent_thread = None;
         if use_threads {
             let res = self.lookup_previous_post(thread_url.to_string(), channel_id.to_string()).await;
-            let option = res.unwrap();
+            let option = res.unwrap_or(None);
             if option != None {
                  parent_thread = option
             }
@@ -258,17 +258,9 @@ impl Slack {
     }
 
     pub async fn lookup_previous_post(&self, thread_url: String, slack_channel: String) -> Result<Option<String>> {
-        // #[derive(Deserialize)]
-        // struct Channel {
-        //     id: Option<String>,
-        //     name: Option<String>,
-        // }
         #[derive(Deserialize)]
         struct SearchMatch {
-            // channel: Option<Channel>,
             ts: Option<String>,
-            // user: Option<String>,
-            // username: Option<String>,
         }
         #[derive(Deserialize)]
         struct Messages {
@@ -298,15 +290,13 @@ impl Slack {
             );
         }
 
-        let messages = resp.messages.unwrap();
+        let messages = resp.messages.unwrap_or(Messages{ total: 0, matches: vec![]});
         if messages.total == 0 {
             return Ok(None);
         }
 
-        let mut result: Vec<SearchMatch> = vec![];
-        result.extend(messages.matches);
-        let x = result.first().unwrap();
-        let option = x.ts.clone();
+        let search_match = messages.matches.first();
+        let option = search_match.unwrap_or(&SearchMatch{ ts: None }).ts.clone();
         Ok(option)
     }
 }

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -140,7 +140,7 @@ impl Slack {
             .slack_db
             .lookup_previous_thread(thread_guid.to_string(), channel_id.to_string())
             .await;
-        let parent_thread = res.unwrap_or(None);
+        let parent_thread = res.unwrap_or_default();
 
         let slack_msg = SlackMessage {
             text: msg.to_string(),

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -275,7 +275,7 @@ impl Slack {
 #[derive(Debug, PartialEq, Clone)]
 pub struct SlackRequest {
     pub channel: SlackRecipient,
-    pub thread_url: Option<String>,
+    pub thread_guid: Option<String>,
     pub msg: String,
     pub attachments: Vec<SlackAttachment>,
     pub initial_thread: bool,
@@ -309,12 +309,12 @@ pub fn req(
     channel: SlackRecipient,
     msg: &str,
     attachments: &[SlackAttachment],
-    thread_url: Option<String>,
+    thread_guid: Option<String>,
     initial_thread: bool,
 ) -> SlackRequest {
     SlackRequest {
         channel,
-        thread_url,
+        thread_guid,
         msg: msg.into(),
         attachments: attachments.into(),
         initial_thread,
@@ -333,7 +333,6 @@ pub fn new_runner(
 #[async_trait::async_trait]
 impl worker::Runner<SlackRequest> for Runner {
     async fn handle(&self, req: SlackRequest) {
-        let url = req.thread_url.unwrap_or_default();
         self.slack
             .send(
                 &req.channel.id,
@@ -341,7 +340,7 @@ impl worker::Runner<SlackRequest> for Runner {
                 &req.msg,
                 req.attachments,
                 req.initial_thread,
-                url.as_str(),
+                req.thread_guid.unwrap_or_default().as_str(),
             )
             .await;
     }

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -371,10 +371,7 @@ pub fn new_runner(
 #[async_trait::async_trait]
 impl worker::Runner<SlackRequest> for Runner {
     async fn handle(&self, req: SlackRequest) {
-        let url = match req.thread_url {
-            Some(ref a) => a.clone(),
-            None => String::new(),
-        };
+        let url = req.thread_url.unwrap_or_default();
         self.slack
             .send(
                 &req.channel.id,

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -314,7 +314,6 @@ impl Slack {
 #[derive(Debug, PartialEq, Clone)]
 pub struct SlackRequest {
     pub channel: SlackRecipient,
-    pub use_threads: bool,
     pub thread_url: Option<String>,
     pub msg: String,
     pub attachments: Vec<SlackAttachment>,
@@ -344,10 +343,9 @@ struct Runner {
     slack: Arc<Slack>,
 }
 
-pub fn req(channel: SlackRecipient, msg: &str, attachments: &[SlackAttachment], use_threads: bool, thread_url: Option<String>) -> SlackRequest {
+pub fn req(channel: SlackRecipient, msg: &str, attachments: &[SlackAttachment], thread_url: Option<String>) -> SlackRequest {
     SlackRequest {
         channel,
-        use_threads,
         thread_url: thread_url.into(),
         msg: msg.into(),
         attachments: attachments.into(),
@@ -376,7 +374,7 @@ impl worker::Runner<SlackRequest> for Runner {
                 &req.channel.name,
                 &req.msg,
                 req.attachments,
-                req.use_threads,
+                req.thread_url != None,
                 url.as_str(),
             )
             .await;

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -276,7 +276,7 @@ impl Slack {
 
         let resp: Resp = self
             .client
-            .get(&format!("/search.messages?query='in:{} from:@octobot has:link {}'", slack_channel, thread_url))
+            .get(&format!("/search.messages?query='in:{} from:@octobot has:link {}'&sort=timestamp", slack_channel, thread_url))
             .await?;
 
         if !resp.ok {

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -317,7 +317,7 @@ pub fn req(
         thread_url,
         msg: msg.into(),
         attachments: attachments.into(),
-        initial_thread: initial_thread,
+        initial_thread,
     }
 }
 

--- a/ops/src/slack_db.rs
+++ b/ops/src/slack_db.rs
@@ -1,0 +1,72 @@
+use failure::format_err;
+use octobot_lib::db::{migrations, Connection, Database};
+use octobot_lib::errors::*;
+
+use crate::slack_db_migrations;
+
+#[derive(Clone)]
+pub struct SlackDatabase {
+    db: Database,
+}
+
+impl SlackDatabase {
+    pub fn new(db_file: &str) -> Result<SlackDatabase> {
+        let db = Database::new(db_file)?;
+
+        let mut connection = db.connect()?;
+
+        let migrations = slack_db_migrations::all_migrations();
+        migrations::migrate(&mut connection, &migrations)?;
+
+        Ok(SlackDatabase { db })
+    }
+
+    pub fn connect(&self) -> Result<Connection> {
+        self.db.connect()
+    }
+
+    pub async fn lookup_previous_thread(
+        &self,
+        thread_url: String,
+        slack_channel: String,
+    ) -> Result<Option<String>> {
+        let result = self.connect()?;
+
+        let thread = result
+            .query_row(
+                "SELECT thread FROM pull_request_threads WHERE guid = ?1 AND channel = ?2 LIMIT 1",
+                &[&thread_url, &slack_channel],
+                |row| row.get(0),
+            )
+            .map_or_else(|_| None, |r| r);
+
+        Ok(thread)
+    }
+
+    pub async fn insert_thread(
+        &self,
+        thread_guid: &str,
+        slack_channel: &str,
+        thread: &str,
+    ) -> Result<()> {
+        let result = self.connect()?;
+
+        result
+            .execute(
+                r#"INSERT INTO repos_jiras (guid, channel, thread, timestamp)
+                    VALUES (?1, ?2, ?3, '?4')"#,
+                &[thread_guid, slack_channel, thread, ""],
+            )
+            .map_err(|e| {
+                format_err!(
+                    "Error inserting slack thread {} - {} - {}: {}",
+                    thread_guid,
+                    slack_channel,
+                    thread,
+                    e
+                )
+            })?;
+
+        Ok(())
+    }
+}

--- a/ops/src/slack_db_migrations.rs
+++ b/ops/src/slack_db_migrations.rs
@@ -1,0 +1,13 @@
+use octobot_lib::db::migrations::{sql, Migration};
+
+pub fn all_migrations() -> Vec<Box<dyn Migration>> {
+    vec![sql(r#"
+    create table pull_request_threads (
+      guid varchar not null,
+      channel varchar not null,
+      thread varchar not null,
+      timestamp integer not null,
+      PRIMARY KEY( guid )
+    );
+    "#)]
+}

--- a/ops/src/slack_db_migrations.rs
+++ b/ops/src/slack_db_migrations.rs
@@ -7,7 +7,7 @@ pub fn all_migrations() -> Vec<Box<dyn Migration>> {
       channel varchar not null,
       thread varchar not null,
       timestamp integer not null,
-      PRIMARY KEY( guid )
+      PRIMARY KEY( guid, channel )
     );
     "#)]
 }


### PR DESCRIPTION
Adds a new option to repo to allow for threading of GitHub content within Slack channels.  The option only applies to public channels.

If the previous message is found using the repo's review channel and the link of the PR, then the message will be sent with the parent thread's ID as the value within `SlackMessage.ts`.
If the previous message cannot be found, then the message will be sent to the channel.