### PR TITLE
chore: update dependencies in build process

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       run: sudo apt-get install libsqlite3-dev libldap2-dev
 
     - name: Install test packages
-      run: sudo apt-get install python firejail
+      run: sudo apt-get install python3.6 firejail
 
     - name: Install stable toolchain
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,4 +45,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: -- -D warnings
+        args: --no-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
      git \
      firejail \
      gosu \
-     python \
+     python3.6 \
      openssl \
      libsqlite3-0 \
      libldap2-dev \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -13,7 +13,7 @@ RUN apt-get update \
      git \
      firejail \
      gosu \
-     python \
+     python3.6 \
      libsqlite3-0 \
      libldap2-dev \
   && rm -fr /var/lib/apt/lists/


### PR DESCRIPTION
Python was no longer downloadable.
Clippy should not inspect dependencies for violations.