### PR TITLE
Fix deleting a repo doesn't delete jira configs

### DIFF
--- a/lib/src/repos.rs
+++ b/lib/src/repos.rs
@@ -658,6 +658,25 @@ mod tests {
     }
 
     #[test]
+    fn test_jira_repos_delete_recreate() {
+        let (mut repos, _temp) = new_test();
+        repos.insert("some-user", "SOME_OTHER_CHANNEL").unwrap();
+
+        // create a repo with jira config
+        let config1 = RepoJiraConfig::new("SER").with_release_branch_regex("release/server-.*");
+        repos.insert_info(&RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1)).unwrap();
+
+        // delete said repo
+        let repo = github::Repo::parse("http://git.company.com/some-user/the-repo").unwrap();
+        let repo_info = repos.lookup_info(&repo).unwrap();
+        repos.delete(repo_info.id.unwrap()).unwrap();
+
+        // reinsert the same repo with the same jira config
+        let config1 = RepoJiraConfig::new("SER").with_release_branch_regex("release/server-.*");
+        repos.insert_info(&RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1)).unwrap();
+    }
+
+    #[test]
     fn test_jira_repos_config() {
         let (mut repos, _temp) = new_test();
         repos.insert("some-user", "SOME_OTHER_CHANNEL").unwrap();

--- a/lib/src/repos.rs
+++ b/lib/src/repos.rs
@@ -670,7 +670,11 @@ mod tests {
 
         // create a repo with jira config
         let config1 = RepoJiraConfig::new("SER").with_release_branch_regex("release/server-.*");
-        repos.insert_info(&RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1)).unwrap();
+        repos
+            .insert_info(
+                &RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1),
+            )
+            .unwrap();
 
         // delete said repo
         let repo = github::Repo::parse("http://git.company.com/some-user/the-repo").unwrap();
@@ -679,7 +683,22 @@ mod tests {
 
         // reinsert the same repo with the same jira config
         let config1 = RepoJiraConfig::new("SER").with_release_branch_regex("release/server-.*");
-        repos.insert_info(&RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1)).unwrap();
+        repos
+            .insert_info(
+                &RepoInfo::new("some-user/the-repo", "the-repo-reviews").with_jira_config(config1),
+            )
+            .unwrap();
+        assert_eq!(vec!["SER"], repos.jira_projects(&repo, "master"));
+        assert_eq!(vec!["SER"], repos.jira_projects(&repo, "main"));
+        assert_eq!(vec!["SER"], repos.jira_projects(&repo, "develop"));
+        assert_eq!(
+            vec!["SER"],
+            repos.jira_projects(&repo, "release/server-1.2")
+        );
+        assert_eq!(
+            Vec::<String>::new(),
+            repos.jira_projects(&repo, "release/other")
+        );
     }
 
     #[test]


### PR DESCRIPTION
The added test creates a repo with jira config, then deletes the repo, then recreates the repo with the same values.  Initially it failed before the fix was put in.

# test run before fix

```

---- repos::tests::test_jira_repos_delete_recreate stdout ----
thread 'repos::tests::test_jira_repos_delete_recreate' panicked at 'called `Result::unwrap()` on an `Err` value: ErrorMessage { msg: "Error inserting jira SER for repo 2: UNIQUE constraint failed: repos_jiras.repo_id, repos_jiras.jira" }', lib/src/repos.rs:676:
111

```