### PR TITLE
feat: allow users to mute DMs for certain repos

### DIFF
--- a/lib/src/config_db_migrations.rs
+++ b/lib/src/config_db_migrations.rs
@@ -70,6 +70,7 @@ pub fn all_migrations() -> Vec<Box<dyn Migration>> {
         sql(r#"alter table users add column slack_id varchar not null default ''"#),
         sql(r#"alter table users add column email varchar not null default ''"#),
         sql(r#"alter table repos add column use_threads tinyint not null default 1"#),
+        sql(r#"alter table users add column muted_repos varchar not null default ''"#),
     ]
 }
 

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -148,7 +148,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: github_name.clone(),
                 mute_direct_messages: db::to_bool(row.get(4)?),
-                muted_repos: row.get::<usize, String>(6)?.split(",").map(|s| s.to_owned()).collect(),
+                muted_repos: row.get::<usize, String>(5)?.split(",").map(|s| s.to_owned()).collect(),
             })
         })?;
 

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -16,6 +16,7 @@ pub struct UserInfo {
     pub slack_id: String,
     pub email: String,
     pub mute_direct_messages: bool,
+    pub muted_repos: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -24,7 +25,7 @@ pub struct UserConfig {
 }
 
 impl UserInfo {
-    pub fn new(git_user: &str, slack_user: &str, slack_id: &str, email: &str) -> UserInfo {
+    pub fn new(git_user: &str, slack_user: &str, slack_id: &str, email: &str, muted_repos: Vec<String>) -> UserInfo {
         UserInfo {
             id: None,
             github: git_user.to_string(),
@@ -32,6 +33,7 @@ impl UserInfo {
             slack_id: slack_id.to_string(),
             email: email.to_string(),
             mute_direct_messages: false,
+            muted_repos,
         }
     }
 }
@@ -42,19 +44,20 @@ impl UserConfig {
     }
 
     pub fn insert(&mut self, git_user: &str, slack_user: &str) -> Result<()> {
-        self.insert_info(&UserInfo::new(git_user, slack_user, "", ""))
+        self.insert_info(&UserInfo::new(git_user, slack_user, "", "", Vec::new()))
     }
 
     pub fn insert_info(&mut self, user: &UserInfo) -> Result<()> {
         let conn = self.db.connect()?;
         conn.execute(
-            "INSERT INTO users (github_name, slack_name, slack_id, email, mute_direct_messages) VALUES (?1, ?2, ?3, ?4, ?5)",
+            "INSERT INTO users (github_name, slack_name, slack_id, email, mute_direct_messages, muted_repos) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             &[
                 &user.github,
                 &user.slack_name,
                 &user.slack_id,
                 &user.email,
                 &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql,
+                &user.muted_repos.join(","),
             ],
         )
         .map_err(|e| format_err!("Error inserting user {}: {}", user.github, e))?;
@@ -65,8 +68,8 @@ impl UserConfig {
     pub fn update(&mut self, user: &UserInfo) -> Result<()> {
         let conn = self.db.connect()?;
         conn.execute(
-            "UPDATE users set github_name = ?1, slack_name = ?2, slack_id = ?3, email = ?4, mute_direct_messages = ?5 where id = ?6",
-            &[&user.github, &user.slack_name, &user.slack_id, &user.email, &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql, &user.id],
+            "UPDATE users set github_name = ?1, slack_name = ?2, slack_id = ?3, email = ?4, mute_direct_messages = ?5, muted_repos = ?6  where id = ?7",
+            &[&user.github, &user.slack_name, &user.slack_id, &user.email, &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql, &user.muted_repos.join(","), &user.id],
         ).map_err(|e| format_err!("Error updating user {}: {}", user.github, e))?;
 
         Ok(())
@@ -84,9 +87,9 @@ impl UserConfig {
         self.lookup_info(github_name).map(|u| u.slack_name)
     }
 
-    pub fn slack_direct_message(&self, github_name: &str) -> Option<SlackRecipient> {
+    pub fn slack_direct_message(&self, github_name: &str, repo_name: &String) -> Option<SlackRecipient> {
         self.lookup_info(github_name).and_then(|u| {
-            if u.mute_direct_messages {
+            if u.mute_direct_messages || u.muted_repos.contains(repo_name){
                 None
             } else if !u.slack_id.is_empty() {
                 Some(SlackRecipient::new(&u.slack_id, &u.slack_name))
@@ -99,7 +102,7 @@ impl UserConfig {
     pub fn get_all(&self) -> Result<Vec<UserInfo>> {
         let conn = self.db.connect()?;
         let mut stmt = conn.prepare(
-            "SELECT id, slack_name, slack_id, email, github_name, mute_direct_messages FROM users ORDER BY github_name",
+            "SELECT id, slack_name, slack_id, email, github_name, mute_direct_messages, muted_repos FROM users ORDER BY github_name",
         )?;
         let found = stmt.query_map([], |row| {
             Ok(UserInfo {
@@ -109,6 +112,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: row.get(4)?,
                 mute_direct_messages: db::to_bool(row.get(5)?),
+                muted_repos: row.get::<usize, String>(6)?.split(",").map(|s| s.to_owned()).collect(),
             })
         })?;
 
@@ -134,7 +138,7 @@ impl UserConfig {
         let github_name = github_name.to_string();
         let conn = self.db.connect()?;
         let mut stmt = conn.prepare(
-            "SELECT id, slack_name, slack_id, email, mute_direct_messages FROM users where github_name = ?1",
+            "SELECT id, slack_name, slack_id, email, mute_direct_messages, muted_repos FROM users where github_name = ?1",
         )?;
         let found = stmt.query_map(&[&github_name], |row| {
             Ok(UserInfo {
@@ -144,6 +148,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: github_name.clone(),
                 mute_direct_messages: db::to_bool(row.get(4)?),
+                muted_repos: row.get::<usize, String>(6)?.split(",").map(|s| s.to_owned()).collect(),
             })
         })?;
 
@@ -170,7 +175,7 @@ mod tests {
         let (users, _temp) = new_test();
 
         assert_eq!(None, users.slack_user_name("joe"));
-        assert_eq!(None, users.slack_direct_message("joe"));
+        assert_eq!(None, users.slack_direct_message("joe", &"repo".into()));
     }
 
     #[test]
@@ -185,17 +190,17 @@ mod tests {
         );
         assert_eq!(
             Some(SlackRecipient::new("@the-slacker", "the-slacker")),
-            users.slack_direct_message("some-git-user")
+            users.slack_direct_message("some-git-user", &"repo".into())
         );
         assert_eq!(None, users.slack_user_name("some.other.user"));
-        assert_eq!(None, users.slack_direct_message("some.other.user"));
+        assert_eq!(None, users.slack_direct_message("some.other.user", &"repo".into()));
     }
 
     #[test]
     fn test_slack_user_name_with_id() {
         let (mut users, _temp) = new_test();
 
-        let info = UserInfo::new("some-git-user", "the-slacker", "1234", "");
+        let info = UserInfo::new("some-git-user", "the-slacker", "1234", "", Vec::new());
         users.insert_info(&info).unwrap();
 
         assert_eq!(
@@ -204,7 +209,29 @@ mod tests {
         );
         assert_eq!(
             Some(SlackRecipient::new("1234", "the-slacker")),
-            users.slack_direct_message("some-git-user")
+            users.slack_direct_message("some-git-user", &"repo".into())
+        );
+    }
+
+    #[test]
+    fn test_muted_repos() {
+        let (mut users, _temp) = new_test();
+
+        let info = UserInfo::new("some-git-user", "the-slacker", "1234", "", vec!["repo1".into(), "repo2".into()]);
+        users.insert_info(&info).unwrap();
+
+        let muted_repos = users.lookup_info("some-git-user").unwrap().muted_repos;
+        assert_eq!(2, muted_repos.len());
+        assert_eq!("repo1", muted_repos[0]);
+        assert_eq!("repo2", muted_repos[1]);
+
+        assert_eq!(
+            None,
+            users.slack_direct_message("some-git-user", &"repo1".into())
+        );
+        assert_eq!(
+            Some(SlackRecipient::new("1234", "the-slacker")),
+            users.slack_direct_message("some-git-user", &"repo3".into())
         );
     }
 }

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -112,7 +112,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: row.get(4)?,
                 mute_direct_messages: db::to_bool(row.get(5)?),
-                muted_repos: row.get::<usize, String>(6)?.split(",").map(|s| s.to_owned()).collect(),
+                muted_repos: row.get::<usize, String>(6)?.split(",").map(|s| s.trim().to_owned()).collect(),
             })
         })?;
 
@@ -148,7 +148,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: github_name.clone(),
                 mute_direct_messages: db::to_bool(row.get(4)?),
-                muted_repos: row.get::<usize, String>(5)?.split(",").map(|s| s.to_owned()).collect(),
+                muted_repos: row.get::<usize, String>(5)?.split(",").map(|s| s.trim().to_owned()).collect(),
             })
         })?;
 
@@ -217,7 +217,7 @@ mod tests {
     fn test_muted_repos() {
         let (mut users, _temp) = new_test();
 
-        let info = UserInfo::new("some-git-user", "the-slacker", "1234", "", vec!["org1/repo1".into(), "org2/repo2".into()]);
+        let info = UserInfo::new("some-git-user", "the-slacker", "1234", "", vec!["  org1/repo1  ".into(), "org2/repo2".into()]);
         users.insert_info(&info).unwrap();
 
         let muted_repos = users.lookup_info("some-git-user").unwrap().muted_repos;

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -242,6 +242,7 @@ app.controller('UsersController', function($scope, sessionHttp, notificationServ
   $scope.addUser = function() {
     $scope.theUser = {
       mute_direct_messages: false,
+      muted_repos: [],
     };
     $('#add-user-modal').modal('show');
   }

--- a/octobot/src/assets/users.html
+++ b/octobot/src/assets/users.html
@@ -41,6 +41,9 @@
               <input type="checkbox" ng-model="theUser.mute_direct_messages"> Mute Direct Messages
             </label>
           </div>
+          <div class="form-group">
+            <input type="text" class="form-control" ng-model="theUser.muted_repos" ng-list placeholder="muted repos">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -123,7 +123,7 @@ impl Messenger {
         attachments: &[SlackAttachment],
     ) {
         for user in users {
-            if let Some(channel) = self.config.users().slack_direct_message(user.login(), &repo.name) {
+            if let Some(channel) = self.config.users().slack_direct_message(user.login(), &repo.full_name) {
                 self.slack
                     .send(slack::req(channel, msg, attachments, None, false));
             }

--- a/ops/src/messenger.rs
+++ b/ops/src/messenger.rs
@@ -48,7 +48,7 @@ impl Messenger {
         // make sure we do not send private message to author of that message
         slackbots.retain(|u| u.login != sender.login && u.login() != "octobot");
 
-        self.send_to_slackbots(slackbots, msg, attachments);
+        self.send_to_slackbots(slackbots, repo, msg, attachments);
     }
 
     pub fn send_to_owner<T: github::CommitLike>(
@@ -69,7 +69,7 @@ impl Messenger {
             Vec::<String>::new(),
             false,
         );
-        self.send_to_slackbots(vec![item_owner.clone()], msg, attachments);
+        self.send_to_slackbots(vec![item_owner.clone()], repo, msg, attachments);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -118,11 +118,12 @@ impl Messenger {
     fn send_to_slackbots(
         &self,
         users: Vec<github::User>,
+        repo: &github::Repo,
         msg: &str,
         attachments: &[SlackAttachment],
     ) {
         for user in users {
-            if let Some(channel) = self.config.users().slack_direct_message(user.login()) {
+            if let Some(channel) = self.config.users().slack_direct_message(user.login(), &repo.name) {
                 self.slack
                     .send(slack::req(channel, msg, attachments, None, false));
             }


### PR DESCRIPTION
This adds a field to users, `muted_repos`. Any messages related to a repo with a name in this list will not trigger slack notifications to the user.