### PR TITLE
fix: use team members url instead of the team url

### DIFF
--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -99,14 +99,14 @@ pub struct App {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Team {
     pub slug: String,
-    pub url: String,
+    pub members_url: String,
 }
 
 impl Team {
-    pub fn new(slug: &str, url: &str) -> Team {
+    pub fn new(slug: &str, members_url: &str) -> Team {
         Team {
             slug: slug.to_string(),
-            url: url.to_string(),
+            members_url: members_url.to_string(),
         }
     }
 }

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -455,7 +455,7 @@ impl GithubEventHandler {
             if let Some(team_members) = team_members {
                 participants.extend(team_members.into_iter());
             } else {
-                let team_members = self.github_session.get_team_members(&t.url).await;
+                let team_members = self.github_session.get_team_members(&t.members_url).await;
                 match team_members {
                     Ok(m) => {
                         participants.extend(m.clone().into_iter());

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -2073,7 +2073,7 @@ async fn test_team_members_cache() {
     test.handler.action = "review_requested".into();
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
-        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-url")]);
+        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url")]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -104,7 +104,7 @@ impl GithubHandlerTest {
     fn mock_get_team_members(&self) -> Vec<User> {
         let users = some_members();
         self.github
-            .mock_get_team_members("http://team-url", Ok(users.clone()));
+            .mock_get_team_members("http://team-members-url", Ok(users.clone()));
 
         users
     }
@@ -1157,7 +1157,7 @@ async fn test_pull_request_review_requested() {
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
         pr.requested_reviewers = Some(vec![User::new("joe-reviewer"), User::new("smith-reviewer")]);
-        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-url")]);
+        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url")]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();


### PR DESCRIPTION
Wrong URL was used to fetch the team members.