### PR TITLE
fix: remove `{/members}` from members url

### DIFF
--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -106,7 +106,9 @@ impl Team {
     pub fn new(slug: &str, members_url: &str) -> Team {
         Team {
             slug: slug.to_string(),
-            members_url: members_url.to_string(),
+            // The members url is formatted as such: `https://api.github.com/teams/1/members{/member}`
+            // So we need to remove `{/member}` at the end.
+            members_url: members_url.split("{").next().unwrap().to_string(),
         }
     }
 }

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -1157,7 +1157,7 @@ async fn test_pull_request_review_requested() {
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
         pr.requested_reviewers = Some(vec![User::new("joe-reviewer"), User::new("smith-reviewer")]);
-        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url")]);
+        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url{/to-remove}")]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -1157,7 +1157,10 @@ async fn test_pull_request_review_requested() {
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
         pr.requested_reviewers = Some(vec![User::new("joe-reviewer"), User::new("smith-reviewer")]);
-        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url{/to-remove}")]);
+        pr.requested_teams = Some(vec![Team::new(
+            "team-awesome",
+            "http://team-members-url{/to-remove}",
+        )]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();


### PR DESCRIPTION
The url from github's `teams` endpoint is returning with `{/members}` at the end causing this error:

```
[2023-07-19 17:29:18,974][139830355396160:runtime-0] - ERROR - Error getting team members: Error looking up team members [https://git.corp.tanium.com/api/v3/organizations/1086/team/525/members{/member}](https://git.corp.tanium.com/api/v3/organizations/1086/team/525/members%7B/member%7D): HTTP s
tatus client error (404 Not Found) for url (https://git.corp.tanium.com/api/v3/organizations/1086/team/525/members%7B/member%7D). Response body: {"message":"Not Found","documentation_url":"https://docs.github/
.com/enterprise-server@3.8/rest"}
```