### PR TITLE
Periodically clean up unused clone dirs

### DIFF
--- a/octobot/src/server/octobot_service.rs
+++ b/octobot/src/server/octobot_service.rs
@@ -41,6 +41,10 @@ impl OctobotService {
             metrics,
         }
     }
+
+    pub fn clean(&self) {
+        self.github_handler_state.clean();
+    }
 }
 
 impl OctobotService {

--- a/ops/src/dir_pool.rs
+++ b/ops/src/dir_pool.rs
@@ -1,20 +1,27 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 pub struct DirPool {
     root_dir: PathBuf,
     available_dirs: Mutex<HashMap<String, AvailableDirs>>,
 }
 
+#[derive(Eq, PartialEq, Clone)]
+struct DirEntry {
+    id: u32,
+    last_used: Instant,
+}
+
 #[derive(Eq, PartialEq)]
 struct AvailableDirs {
     next_new: u32,
-    unused: Vec<u32>,
+    unused: Vec<DirEntry>,
 }
 
 pub struct HeldDir {
-    id: u32,
+    entry: DirEntry,
     repo_root: PathBuf,
     dir: PathBuf,
     pool: Arc<DirPool>,
@@ -34,6 +41,10 @@ impl ArcDirPool {
     pub fn take_directory(&self, host: &str, owner: &str, repo: &str) -> HeldDir {
         DirPool::take_directory(self.pool.clone(), host, owner, repo)
     }
+
+    pub fn clean(&self, expiration: Duration) {
+        self.pool.clean(expiration)
+    }
 }
 
 impl DirPool {
@@ -48,22 +59,50 @@ impl DirPool {
         let repo_root = pool.root_dir.join(host).join(owner).join(repo);
         let key = repo_root.to_string_lossy().into_owned();
 
-        let id;
+        let entry;
         {
             let mut dirs = pool.available_dirs.lock().unwrap();
-            let entry = dirs.entry(key).or_insert_with(AvailableDirs::new);
-            id = entry.get_id();
+            let dir = dirs.entry(key).or_insert_with(AvailableDirs::new);
+            entry = dir.get_entry();
         }
 
-        HeldDir::new(id, repo_root, pool)
+        HeldDir::new(entry, repo_root, pool)
     }
 
-    fn return_dir(&self, id: u32, repo_root: &Path) {
+    fn return_dir(&self, entry: DirEntry, repo_root: &Path) {
         let key = repo_root.to_string_lossy().into_owned();
         {
             let mut dirs = self.available_dirs.lock().unwrap();
-            let entry = dirs.entry(key).or_insert_with(AvailableDirs::new);
-            entry.return_id(id);
+            let dir = dirs.entry(key).or_insert_with(AvailableDirs::new);
+            dir.return_entry(entry);
+        }
+    }
+
+    pub fn clean(&self, expiration: Duration) {
+        let deadline = Instant::now() - expiration;
+        let mut locked_dirs = self.available_dirs.lock().unwrap();
+        for (repo_root_str, dirs) in locked_dirs.iter_mut() {
+            let repo_root = Path::new(repo_root_str);
+
+            let new_dirs = dirs
+                .unused
+                .clone()
+                .into_iter()
+                .filter_map(|dir| {
+                    if dir.last_used < deadline {
+                        let path = repo_root.join(dir.id.to_string());
+
+                        if let Err(e) = std::fs::remove_dir_all(&path) {
+                            log::error!("Failed to remove stale directory {:?}: {}", path, e);
+                        }
+
+                        None
+                    } else {
+                        Some(dir)
+                    }
+                })
+                .collect::<Vec<_>>();
+            dirs.unused = new_dirs;
         }
     }
 }
@@ -76,26 +115,31 @@ impl AvailableDirs {
         }
     }
 
-    pub fn get_id(&mut self) -> u32 {
+    pub fn get_entry(&mut self) -> DirEntry {
         match self.unused.pop() {
-            Some(id) => id,
+            Some(d) => d,
             None => {
                 self.next_new += 1;
-                self.next_new
+                DirEntry {
+                    id: self.next_new,
+                    last_used: Instant::now(),
+                }
             }
         }
     }
 
-    pub fn return_id(&mut self, id: u32) {
-        self.unused.push(id);
+    pub fn return_entry(&mut self, mut d: DirEntry) {
+        d.last_used = Instant::now();
+        self.unused.push(d);
     }
 }
 
 impl HeldDir {
-    fn new(id: u32, repo_root: PathBuf, pool: Arc<DirPool>) -> HeldDir {
+    fn new(entry: DirEntry, repo_root: PathBuf, pool: Arc<DirPool>) -> HeldDir {
+        let dir = repo_root.join(entry.id.to_string());
         HeldDir {
-            id,
-            dir: repo_root.join(id.to_string()),
+            entry,
+            dir,
             repo_root,
             pool,
         }
@@ -108,7 +152,8 @@ impl HeldDir {
 
 impl Drop for HeldDir {
     fn drop(&mut self) {
-        self.pool.return_dir(self.id, &self.repo_root)
+        let entry = self.entry.clone();
+        self.pool.return_dir(entry, &self.repo_root)
     }
 }
 
@@ -123,12 +168,15 @@ mod tests {
         assert_eq!(0, dirs.next_new);
         assert_eq!(0, dirs.unused.len());
 
-        assert_eq!(1, dirs.get_id());
-        assert_eq!(2, dirs.get_id());
+        let entry1 = dirs.get_entry();
+        let entry2 = dirs.get_entry();
 
-        dirs.return_id(1);
-        assert_eq!(1, dirs.get_id());
-        assert_eq!(3, dirs.get_id());
+        assert_eq!(1, entry1.id);
+        assert_eq!(2, entry2.id);
+
+        dirs.return_entry(entry1);
+        assert_eq!(1, dirs.get_entry().id);
+        assert_eq!(3, dirs.get_entry().id);
     }
 
     #[test]

--- a/ops/src/git_clone_manager.rs
+++ b/ops/src/git_clone_manager.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use failure::format_err;
 use log::info;
@@ -40,6 +41,10 @@ impl GitCloneManager {
         self.clone_repo(&session, owner, repo, held_clone_dir.dir())?;
 
         Ok(held_clone_dir)
+    }
+
+    pub fn clean(&self, expiration: Duration) {
+        self.dir_pool.clean(expiration);
     }
 
     fn clone_repo(


### PR DESCRIPTION
Rather than hold on to clone directories forever,
we should clean them up if they are unused for a
long enough time.
