### PR TITLE
Change teams lookup to use team id

### DIFF
--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -130,7 +130,7 @@ pub trait Session: Send + Sync {
         check_run_id: u32,
         run: &CheckRun,
     ) -> Result<()>;
-    async fn get_team_members(&self, url: &str) -> Result<Vec<User>>;
+    async fn get_team_members(&self, repo: &Repo, id: u32) -> Result<Vec<User>>;
 }
 
 #[async_trait]
@@ -963,10 +963,20 @@ impl Session for GithubSession {
         Ok(())
     }
 
-    async fn get_team_members(&self, url: &str) -> Result<Vec<User>> {
+    async fn get_team_members(&self, repo: &Repo, team_id: u32) -> Result<Vec<User>> {
         self.client
-            .get(url)
+            .get(&format!(
+                "/organizations/{}/team/{}/members",
+                repo.owner.id, team_id
+            ))
             .await
-            .map_err(|e| format_err!("Error looking up team members {}: {}", url, e))
+            .map_err(|e| {
+                format_err!(
+                    "Error looking up team members {} for repo {}: {}",
+                    team_id,
+                    repo.full_name,
+                    e
+                )
+            })
     }
 }

--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -98,22 +98,15 @@ pub struct App {
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Team {
+    pub id: u32,
     pub slug: String,
-    pub members_url: String,
 }
 
 impl Team {
-    pub fn new(slug: &str, members_url: &str) -> Team {
-        // The members url is formatted as such: `https://api.github.com/teams/1/members{/member}`
-        // So we need to remove `{/member}` at the end.
-        let first_str = members_url.split("{").next();
-        let url = match first_str {
-            None => "",
-            Some(u) => u,
-        };
+    pub fn new(id: u32, slug: &str) -> Team {
         Team {
-            slug: slug.to_string(),
-            members_url: url.to_string(),
+            id,
+            slug: slug.into(),
         }
     }
 }
@@ -126,6 +119,7 @@ impl PartialEq for Team {
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct User {
+    pub id: u32,
     pub login: Option<String>,
     pub name: Option<String>,
 }
@@ -133,6 +127,7 @@ pub struct User {
 impl User {
     pub fn new(login: &str) -> User {
         User {
+            id: 0,
             login: Some(login.to_string()),
             name: Some(login.to_string()),
         }
@@ -230,6 +225,7 @@ pub trait PullRequestLike: Send + Sync {
     fn html_url(&self) -> &str;
     fn number(&self) -> u32;
     fn has_commits(&self) -> bool;
+    fn repo(&self) -> Option<&Repo>;
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -333,6 +329,10 @@ impl<'a> PullRequestLike for &'a PullRequest {
     fn has_commits(&self) -> bool {
         true
     }
+
+    fn repo(&self) -> Option<&Repo> {
+        Some(&self.base.repo)
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -371,6 +371,10 @@ impl<'a> PullRequestLike for &'a Issue {
 
     fn has_commits(&self) -> bool {
         false
+    }
+
+    fn repo(&self) -> Option<&Repo> {
+        None
     }
 }
 

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -101,10 +101,10 @@ impl GithubHandlerTest {
         commits
     }
 
-    fn mock_get_team_members(&self) -> Vec<User> {
+    fn mock_get_team_members(&self, team_id: u32) -> Vec<User> {
         let users = some_members();
         self.github
-            .mock_get_team_members("http://team-members-url", Ok(users.clone()));
+            .mock_get_team_members(&the_repo(), team_id, Ok(users.clone()));
 
         users
     }
@@ -1157,14 +1157,11 @@ async fn test_pull_request_review_requested() {
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
         pr.requested_reviewers = Some(vec![User::new("joe-reviewer"), User::new("smith-reviewer")]);
-        pr.requested_teams = Some(vec![Team::new(
-            "team-awesome",
-            "http://team-members-url{/to-remove}",
-        )]);
+        pr.requested_teams = Some(vec![Team::new(100, "team-awesome")]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();
-    test.mock_get_team_members();
+    test.mock_get_team_members(100);
 
     let attach = vec![SlackAttachmentBuilder::new("")
         .title("Pull Request #32: \"The PR\"")
@@ -2076,12 +2073,12 @@ async fn test_team_members_cache() {
     test.handler.action = "review_requested".into();
     test.handler.data.pull_request = some_pr();
     if let Some(ref mut pr) = test.handler.data.pull_request {
-        pr.requested_teams = Some(vec![Team::new("team-awesome", "http://team-members-url")]);
+        pr.requested_teams = Some(vec![Team::new(100, "team-awesome")]);
     }
     test.handler.data.sender = User::new("the-pr-closer");
     test.mock_pull_request_commits();
     test.mock_pull_request_commits();
-    test.mock_get_team_members();
+    test.mock_get_team_members(100);
 
     let attach = vec![SlackAttachmentBuilder::new("")
         .title("Pull Request #32: \"The PR\"")

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -476,11 +476,12 @@ impl Session for MockGithub {
         call.ret
     }
 
-    async fn get_team_members(&self, url: &str) -> Result<Vec<User>> {
+    async fn get_team_members(&self, repo: &Repo, team_id: u32) -> Result<Vec<User>> {
         let mut calls = self.get_team_members_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to get_team_members");
         let call = calls.remove(0);
-        assert_eq!(call.args[0], url.to_string());
+        assert_eq!(call.args[0], repo.full_name);
+        assert_eq!(call.args[1], team_id.to_string());
 
         call.ret
     }
@@ -707,11 +708,14 @@ impl MockGithub {
             ));
     }
 
-    pub fn mock_get_team_members(&self, url: &str, ret: Result<Vec<User>>) {
+    pub fn mock_get_team_members(&self, repo: &Repo, team_id: u32, ret: Result<Vec<User>>) {
         self.get_team_members_calls
             .lock()
             .unwrap()
-            .push(MockCall::new(ret, vec![&url.to_string()]));
+            .push(MockCall::new(
+                ret,
+                vec![&repo.full_name, &team_id.to_string()],
+            ));
     }
 }
 


### PR DESCRIPTION
Using the members_url and removing `{/members}` wasn't working, and
kinda relied on a contract that didn't seem guaranteed.

Changed up the team member lookup to use (org_id, team_id). We didn't
do this before to avoid yet another lookup for the team org, but then
realized that teams must belong to the organization that the PR belongs to.
So, we already have the org id.
