### PR TITLE
Dependabot lib updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -42,21 +42,6 @@ name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "async-trait"
@@ -83,7 +68,7 @@ checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -128,16 +113,6 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
@@ -153,39 +128,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "time 0.1.45",
- "wasm-bindgen",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "conventional"
@@ -214,54 +159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils",
- "lazy_static",
- "maybe-uninit",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,7 +170,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -387,56 +284,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags 1.3.2",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
-name = "futures"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -444,34 +297,6 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
 
 [[package]]
 name = "futures-sink"
@@ -491,16 +316,10 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -515,7 +334,7 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -523,7 +342,7 @@ dependencies = [
  "http",
  "indexmap 1.9.3",
  "slab",
- "tokio 1.29.1",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
@@ -571,7 +390,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -582,7 +401,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
@@ -611,7 +430,7 @@ version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -623,7 +442,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2",
- "tokio 1.29.1",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -635,34 +454,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "hyper",
  "native-tls",
- "tokio 1.29.1",
+ "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -704,15 +500,6 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -762,16 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,15 +584,6 @@ checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
@@ -837,25 +605,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -874,55 +627,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
 ]
 
 [[package]]
@@ -941,17 +652,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1005,6 +705,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,10 +727,9 @@ name = "octobot"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "chrono",
  "env_logger",
  "failure",
- "futures 0.3.28",
+ "hex",
  "http",
  "hyper",
  "log",
@@ -1032,15 +740,13 @@ dependencies = [
  "prometheus",
  "regex",
  "ring",
- "rustc-serialize",
  "serde",
  "serde_derive",
  "serde_json",
- "tempdir",
+ "tempfile",
  "thread-id",
- "tokio 1.29.1",
- "tokio-core",
- "tokio-threadpool",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -1061,9 +767,9 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
- "chrono",
  "conventional",
  "failure",
+ "hex",
  "jsonwebtoken",
  "log",
  "maplit",
@@ -1073,11 +779,11 @@ dependencies = [
  "reqwest",
  "ring",
  "rusqlite",
- "rustc-serialize",
  "serde",
  "serde_derive",
  "serde_json",
- "tempdir",
+ "tempfile",
+ "time",
  "toml",
  "url",
 ]
@@ -1098,8 +804,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tempdir",
- "tokio 1.29.1",
+ "tempfile",
+ "tokio",
  "unidiff",
 ]
 
@@ -1107,11 +813,11 @@ dependencies = [
 name = "octobot_utils"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "octobot_lib",
  "regex",
  "ring",
  "rpassword",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -1136,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1175,38 +881,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.3",
- "rustc_version",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.10",
- "parking_lot_core 0.9.8",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66b810a62be75176a80873726630147a5ca780cd33921e0b5709033e66b0a"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version",
- "smallvec 0.6.14",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1215,10 +895,10 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
- "smallvec 1.11.0",
+ "smallvec",
  "windows-targets 0.48.1",
 ]
 
@@ -1283,12 +963,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fnv",
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot 0.12.1",
+ "parking_lot",
  "procfs",
  "protobuf",
  "thiserror",
@@ -1308,49 +988,6 @@ checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -1400,22 +1037,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.2",
- "bytes 1.4.0",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1435,7 +1063,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.29.1",
+ "tokio",
  "tokio-native-tls",
  "tower-service",
  "url",
@@ -1457,7 +1085,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1468,7 +1096,7 @@ checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
 dependencies = [
  "libc",
  "rtoolbox",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1478,7 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1492,7 +1120,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.11.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -1500,21 +1128,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1559,12 +1172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,21 +1199,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -1669,7 +1261,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.25",
+ "time",
 ]
 
 [[package]]
@@ -1679,15 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
 ]
 
 [[package]]
@@ -1703,7 +1286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1747,22 +1330,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix 0.38.7",
@@ -1806,18 +1379,7 @@ checksum = "3ee93aa2b8331c0fec9091548843f2c90019571814057da3b783f9de09349d73"
 dependencies = [
  "libc",
  "redox_syscall 0.2.16",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1828,6 +1390,8 @@ checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1865,116 +1429,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "mio 0.6.23",
- "num_cpus",
- "tokio-codec",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-fs",
- "tokio-io",
- "tokio-reactor",
- "tokio-sync",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "tokio-udp",
- "tokio-uds",
-]
-
-[[package]]
-name = "tokio"
 version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
  "backtrace",
- "bytes 1.4.0",
+ "bytes",
  "libc",
- "mio 0.8.8",
+ "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-codec"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "tokio-io",
-]
-
-[[package]]
-name = "tokio-core"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b1395334443abca552f63d4f61d0486f12377c2ba8b368e523f89e828cffd4"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "log",
- "mio 0.6.23",
- "scoped-tls",
- "tokio 0.1.22",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-timer",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
-dependencies = [
- "futures 0.1.31",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-executor"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-fs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
-dependencies = [
- "futures 0.1.31",
- "tokio-io",
- "tokio-threadpool",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
 ]
 
 [[package]]
@@ -1995,112 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio 1.29.1",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "mio 0.6.23",
- "num_cpus",
- "parking_lot 0.9.0",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
-dependencies = [
- "fnv",
- "futures 0.1.31",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "mio 0.6.23",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-threadpool"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-queue",
- "crossbeam-utils",
- "futures 0.1.31",
- "lazy_static",
- "log",
- "num_cpus",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-timer"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.31",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
-name = "tokio-udp"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
- "mio 0.6.23",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
-]
-
-[[package]]
-name = "tokio-uds"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "iovec",
- "libc",
- "log",
- "mio 0.6.23",
- "mio-uds",
- "tokio-codec",
- "tokio-io",
- "tokio-reactor",
+ "tokio",
 ]
 
 [[package]]
@@ -2109,11 +1472,11 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
- "bytes 1.4.0",
+ "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio 1.29.1",
+ "tokio",
  "tracing",
 ]
 
@@ -2163,7 +1526,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2270,12 +1633,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2286,7 +1643,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -2311,7 +1668,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2358,12 +1715,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2371,12 +1722,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2390,7 +1735,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2398,15 +1743,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.1",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2555,15 +1891,5 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,6 @@ log = "0.4.19"
 regex = "1.9.3"
 ring = "0.16.20"
 rusqlite = "0.29.0"
-rustc-serialize = "0.3.24"
 serde = "1.0.183"
 serde_derive = "1.0.183"
 serde_json = "1.0.104"
@@ -27,9 +26,10 @@ jsonwebtoken = "8.3.0"
 reqwest = { version = "0.11.18", features = ["json"] }
 async-trait = "0.1.72"
 percent-encoding = "2.3.0"
-chrono = "0.4.26"
 prometheus = { version = "0.13.3", features = ["process"] }
 maplit = "1.0.2"
+hex = "0.4.3"
+time = "0.3.25"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3"

--- a/lib/src/config_db.rs
+++ b/lib/src/config_db.rs
@@ -32,11 +32,11 @@ fn migrate(conn: &mut Connection) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[test]
     fn test_migration_versions() {
-        let temp_dir = TempDir::new("users.rs").unwrap();
+        let temp_dir = tempdir().unwrap();
         let db_file = temp_dir.path().join("db.sqlite3");
         let mut conn = Connection::open(&db_file).expect("create temp database");
 
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn test_multiple_migration() {
-        let temp_dir = TempDir::new("users.rs").unwrap();
+        let temp_dir = tempdir().unwrap();
         let db_file = temp_dir.path().join("db.sqlite3");
         let mut conn = Connection::open(&db_file).expect("create temp database");
 

--- a/lib/src/github/models_checks.rs
+++ b/lib/src/github/models_checks.rs
@@ -5,6 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde;
 use serde::de::{self, Deserialize as Deserialize2, Deserializer, Visitor};
 use serde::ser::{Serialize as Serialize2, Serializer};
+use time::format_description::well_known::Rfc3339;
 
 use crate::github::models;
 
@@ -99,9 +100,11 @@ impl CheckRun {
     }
 
     pub fn completed(mut self, conclusion: Conclusion) -> CheckRun {
+        let now = time::OffsetDateTime::now_utc();
+
         self.status = CheckStatus::Completed;
         self.conclusion = Some(conclusion);
-        self.completed_at = Some(chrono::Utc::now().to_rfc3339());
+        self.completed_at = Some(now.format(&Rfc3339).expect("time format"));
         self
     }
 }

--- a/lib/src/passwd.rs
+++ b/lib/src/passwd.rs
@@ -1,6 +1,5 @@
 use log::error;
 use ring::{digest, pbkdf2};
-use rustc_serialize::hex::{FromHex, ToHex};
 
 static DIGEST_ALG: &pbkdf2::Algorithm = &pbkdf2::PBKDF2_HMAC_SHA256;
 const CREDENTIAL_LEN: usize = digest::SHA256_OUTPUT_LEN;
@@ -19,11 +18,11 @@ pub fn store_password(pass: &str, salt: &str) -> String {
         &mut pass_hash,
     );
 
-    pass_hash.to_hex()
+    hex::encode(pass_hash)
 }
 
 pub fn verify_password(pass: &str, salt: &str, pass_hash: &str) -> bool {
-    let pass_hash = match pass_hash.from_hex() {
+    let pass_hash = match hex::decode(pass_hash) {
         Ok(h) => h,
         Err(e) => {
             error!("Invalid password hash stored: {} -- {}", pass_hash, e);

--- a/lib/src/repos.rs
+++ b/lib/src/repos.rs
@@ -414,10 +414,10 @@ impl RepoConfig {
 mod tests {
     use super::*;
     use github;
-    use tempdir::TempDir;
+    use tempfile::{tempdir, TempDir};
 
     fn new_test() -> (RepoConfig, TempDir) {
-        let temp_dir = TempDir::new("repos.rs").unwrap();
+        let temp_dir = tempdir().unwrap();
         let db_file = temp_dir.path().join("db.sqlite3");
         let db = ConfigDatabase::new(&db_file.to_string_lossy()).expect("create temp database");
 

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -180,10 +180,10 @@ impl UserConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::{tempdir, TempDir};
 
     fn new_test() -> (UserConfig, TempDir) {
-        let temp_dir = TempDir::new("users.rs").unwrap();
+        let temp_dir = tempdir().unwrap();
         let db_file = temp_dir.path().join("db.sqlite3");
         let db = ConfigDatabase::new(&db_file.to_string_lossy()).expect("create temp database");
 

--- a/octobot/Cargo.toml
+++ b/octobot/Cargo.toml
@@ -25,19 +25,16 @@ hyper = { version = "0.14.27", features = ["server"] }
 log = "0.4.19"
 regex = "1.9.3"
 ring = "0.16.20"
-rustc-serialize = "0.3.24"
 serde = "1.0.183"
 serde_derive = "1.0.183"
 serde_json = "1.0.104"
 thread-id = "4.1.0"
 tokio = { version = "1.29.1", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-core = "0.1.18"
-tokio-threadpool = "0.1.18"
 async-trait = "0.1.72"
-chrono = "0.4.26"
 prometheus = "0.13.3"
 maplit = "1.0.2"
-futures = "0.3.28"
+time = { version = "0.3.25", features = ["local-offset"]}
+hex = "0.4.3"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3"

--- a/octobot/src/main.rs
+++ b/octobot/src/main.rs
@@ -55,13 +55,16 @@ fn run() -> Result<()> {
 }
 
 fn setup_logging() {
-    let formatter = |buf: &mut env_logger::fmt::Formatter, record: &log::Record| {
-        let now = chrono::Local::now();
+    let format = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+        .expect("invalid time format");
+
+    let formatter = move |buf: &mut env_logger::fmt::Formatter, record: &log::Record| {
+        let now = time::OffsetDateTime::now_local().expect("now");
         writeln!(
             buf,
             "[{},{:03}][{}:{}] - {} - {}",
-            now.format("%Y-%m-%d %H:%M:%S"),
-            now.timestamp_subsec_millis(),
+            now.format(&format).expect("cannot format time"),
+            now.millisecond(),
             thread_id::get(),
             std::thread::current().name().unwrap_or(""),
             record.level(),

--- a/octobot/src/server/github_verify.rs
+++ b/octobot/src/server/github_verify.rs
@@ -1,7 +1,6 @@
 use hyper::HeaderMap;
 use log::{debug, error};
 use ring::hmac;
-use rustc_serialize::hex::FromHex;
 
 pub struct GithubWebhookVerifier {
     pub secret: String,
@@ -35,7 +34,7 @@ impl GithubWebhookVerifier {
             return false;
         }
 
-        let sig_bytes: Vec<u8> = match signature[5..].from_hex() {
+        let sig_bytes: Vec<u8> = match hex::decode(&signature[5..]) {
             Ok(s) => s,
             Err(e) => {
                 error!("Invalid hex value. {}", e);
@@ -61,7 +60,6 @@ impl GithubWebhookVerifier {
 mod tests {
     use super::*;
     use ring::hmac;
-    use rustc_serialize::hex::ToHex;
 
     #[test]
     fn verify_sig_valid() {
@@ -70,7 +68,7 @@ mod tests {
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());
-        let signature_hex = "sha1=".to_string() + signature.as_ref().to_hex().as_str();
+        let signature_hex = "sha1=".to_string() + hex::encode(signature.as_ref()).as_str();
 
         let verifier = GithubWebhookVerifier { secret: key_value };
 
@@ -84,7 +82,7 @@ mod tests {
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());
-        let signature_hex = "sha9=".to_string() + signature.as_ref().to_hex().as_str();
+        let signature_hex = "sha9=".to_string() + hex::encode(signature.as_ref()).as_str();
 
         let verifier = GithubWebhookVerifier { secret: key_value };
 
@@ -98,7 +96,7 @@ mod tests {
 
         let msg = "a message from the githubs.";
         let signature = hmac::sign(&key, msg.as_bytes());
-        let signature_hex = signature.as_ref().to_hex();
+        let signature_hex = hex::encode(signature.as_ref());
 
         let verifier = GithubWebhookVerifier { secret: key_value };
 

--- a/octobot/src/server/sessions.rs
+++ b/octobot/src/server/sessions.rs
@@ -3,7 +3,6 @@ use std::time::{Duration, Instant};
 
 use ring::rand::SecureRandom;
 use ring::rand::SystemRandom;
-use rustc_serialize::hex::ToHex;
 
 static SESSION_EXPIRY_SECS: u64 = 15 * 60;
 static PRUNE_SECS: u64 = 30;
@@ -33,7 +32,7 @@ impl Sessions {
         // Doesn't look like SecureRandom, but docs claim it is.
         SystemRandom::new().fill(&mut bytes).expect("get random");
 
-        let sess_id = bytes.to_hex();
+        let sess_id = hex::encode(bytes);
         let session = Session {
             id: sess_id.clone(),
             created_at: Instant::now(),

--- a/octobot/tests/git_helper/temp_git.rs
+++ b/octobot/tests/git_helper/temp_git.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use std::io::Write;
 use std::path::PathBuf;
 
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 use octobot_ops::git::Git;
 
@@ -16,13 +16,13 @@ pub struct TempGit {
 
 impl TempGit {
     pub fn new() -> TempGit {
-        let home = TempDir::new("home")
+        let home = tempdir()
             .expect("create fake home dir for configs")
             .into_path();
         std::env::set_var("HOME", &home);
         std::env::set_var("XDG_CONFIG_HOME", &home);
 
-        let dir = TempDir::new("git_test.rs").expect("create temp dir for git_test.rs");
+        let dir = tempdir().expect("create temp dir for git_test.rs");
 
         let repo_dir = dir.path().join("repo");
         let remote_dir = dir.path().join("remote");

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use failure::format_err;
 use hyper::StatusCode;
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 use mocks::mock_github::MockGithub;
 use mocks::mock_jira::MockJira;
@@ -121,7 +121,7 @@ fn new_test_with(jira: Option<JiraConfig>) -> GithubHandlerTest {
     let repo_version = LockedMockWorker::new("repo-version");
     let force_push = LockedMockWorker::new("force-push");
 
-    let temp_dir = TempDir::new("github_handler_test.rs").unwrap();
+    let temp_dir = tempdir().unwrap();
     let db_file = temp_dir.path().join("db.sqlite3");
     let db = ConfigDatabase::new(&db_file.to_string_lossy()).expect("create temp database");
 

--- a/octobot/tests/messenger_test.rs
+++ b/octobot/tests/messenger_test.rs
@@ -2,7 +2,7 @@ mod mocks;
 
 use std::sync::Arc;
 
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 use mocks::mock_slack::MockSlack;
 use octobot_lib::config::Config;
@@ -13,7 +13,7 @@ use octobot_ops::messenger;
 use octobot_ops::slack;
 
 fn new_test() -> (Arc<Config>, TempDir) {
-    let temp_dir = TempDir::new("repos.rs").unwrap();
+    let temp_dir = tempdir().unwrap();
     let db_file = temp_dir.path().join("db.sqlite3");
     let db = ConfigDatabase::new(&db_file.to_string_lossy()).expect("create temp database");
 

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -3,7 +3,7 @@ mod mocks;
 
 use std::sync::Arc;
 
-use tempdir::TempDir;
+use tempfile::{tempdir, TempDir};
 
 use git_helper::temp_git::TempGit;
 use mocks::mock_github::MockGithub;
@@ -27,7 +27,7 @@ struct PRMergeTest {
 }
 
 fn new_test() -> (PRMergeTest, TempDir) {
-    let temp_dir = TempDir::new("repos.rs").unwrap();
+    let temp_dir = tempdir().unwrap();
     let db_file = temp_dir.path().join("db.sqlite3");
     let db = ConfigDatabase::new(&db_file.to_string_lossy()).expect("create temp database");
 

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -25,5 +25,5 @@ async-trait = "0.1.72"
 serde_json = "1.0.104"
 
 [dev-dependencies]
-tempdir = "0.3.7"
 maplit = "1.0.2"
+tempfile = "3"

--- a/ops/src/repo_version.rs
+++ b/ops/src/repo_version.rs
@@ -318,12 +318,11 @@ mod tests {
     use std::fs;
     use std::io::Write;
 
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[test]
     fn test_run_script() {
-        let dir =
-            TempDir::new("repo_version.rs").expect("create temp dir for repo_version.rs test");
+        let dir = tempdir().unwrap();
 
         let sub_dir = dir.path().join("subdir");
         fs::create_dir(&sub_dir).expect("create subdir");
@@ -339,8 +338,7 @@ mod tests {
 
     #[test]
     fn test_run_script_failure() {
-        let dir =
-            TempDir::new("repo_version.rs").expect("create temp dir for repo_version.rs test");
+        let dir = tempdir().unwrap();
 
         let sub_dir = dir.path().join("subdir");
         fs::create_dir(&sub_dir).expect("create subdir");
@@ -360,8 +358,7 @@ mod tests {
 
     #[test]
     fn test_run_script_failure_firejail_error() {
-        let dir =
-            TempDir::new("repo_version.rs").expect("create temp dir for repo_version.rs test");
+        let dir = tempdir().unwrap();
 
         let sub_dir = dir.path().join("subdir");
         fs::create_dir(&sub_dir).expect("create subdir");
@@ -379,8 +376,7 @@ mod tests {
 
     #[test]
     fn test_run_python_script() {
-        let dir =
-            TempDir::new("repo_version.rs").expect("create temp dir for repo_version.rs test");
+        let dir = tempdir().unwrap();
 
         let sub_dir = dir.path().join("subdir");
         fs::create_dir(&sub_dir).expect("create subdir");
@@ -404,8 +400,7 @@ mod tests {
             return;
         }
 
-        let dir =
-            TempDir::new("repo_version.rs").expect("create temp dir for repo_version.rs test");
+        let dir = tempdir().unwrap();
 
         let parent_file = dir.path().join("private.txt");
         {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,6 +17,6 @@ path = "src/octobot-passwd.rs"
 [dependencies]
 rpassword = "7.2.0"
 ring = "0.16.20"
-rustc-serialize = "0.3.24"
 regex = "1.9.3"
 octobot_lib = { "path" = "../lib" }
+hex = "0.4.3"

--- a/utils/src/octobot-passwd.rs
+++ b/utils/src/octobot-passwd.rs
@@ -1,6 +1,5 @@
 use ring::rand::SecureRandom;
 use ring::rand::SystemRandom;
-use rustc_serialize::hex::ToHex;
 
 use octobot_lib::config;
 use octobot_lib::passwd;
@@ -27,7 +26,7 @@ fn main() {
     SystemRandom::new()
         .fill(&mut salt_bytes)
         .expect("get random");
-    let salt: String = salt_bytes.to_hex();
+    let salt: String = hex::encode(salt_bytes);
 
     let pass_hash = passwd::store_password(&pass1, &salt);
 


### PR DESCRIPTION
- Remove old tokio
- Drop rustc_serialize for hex
- Drop chrono for time
- Drop tempdir for tempfile
