### PR TITLE
Fix slack db to be a singleton

### DIFF
--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -122,7 +122,11 @@ impl GithubHandlerState {
 
         let slack_worker = TokioWorker::new_worker(
             runtime.clone(),
-            slack::new_runner(config.slack.bot_token.clone(), metrics.clone()),
+            slack::new_runner(
+                config.slack.bot_token.clone(),
+                config.slack_db_path(),
+                metrics.clone(),
+            ),
         );
         let pr_merge_worker = TokioWorker::new_worker(
             runtime.clone(),

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -21,7 +21,7 @@ use octobot_ops::git_clone_manager::GitCloneManager;
 use octobot_ops::messenger::{self, Messenger};
 use octobot_ops::pr_merge::{self, PRMergeRequest};
 use octobot_ops::repo_version::{self, RepoVersionRequest};
-use octobot_ops::slack::{self, SlackAttachmentBuilder, SlackRequest};
+use octobot_ops::slack::{self, Slack, SlackAttachmentBuilder, SlackRequest};
 use octobot_ops::util;
 use octobot_ops::worker::{TokioWorker, Worker};
 
@@ -110,6 +110,7 @@ impl GithubHandlerState {
         config: Arc<Config>,
         github_app: Arc<dyn github::api::GithubSessionFactory>,
         jira_session: Option<Arc<dyn jira::api::Session>>,
+        slack: Arc<Slack>,
         metrics: Arc<Metrics>,
     ) -> GithubHandlerState {
         let git_clone_manager = Arc::new(GitCloneManager::new(github_app.clone(), config.clone()));
@@ -120,14 +121,8 @@ impl GithubHandlerState {
             metrics.clone(),
         )));
 
-        let slack_worker = TokioWorker::new_worker(
-            runtime.clone(),
-            slack::new_runner(
-                config.slack.bot_token.clone(),
-                config.slack_db_path(),
-                metrics.clone(),
-            ),
-        );
+        let slack_worker =
+            TokioWorker::new_worker(runtime.clone(), slack::new_runner(slack.clone()));
         let pr_merge_worker = TokioWorker::new_worker(
             runtime.clone(),
             pr_merge::new_runner(
@@ -184,9 +179,10 @@ impl GithubHandler {
         config: Arc<Config>,
         github_app: Arc<dyn github::api::GithubSessionFactory>,
         jira_session: Option<Arc<dyn jira::api::Session>>,
+        slack: Arc<Slack>,
         metrics: Arc<Metrics>,
     ) -> Box<GithubHandler> {
-        let state = GithubHandlerState::new(config, github_app, jira_session, metrics);
+        let state = GithubHandlerState::new(config, github_app, jira_session, slack, metrics);
         GithubHandler::from_state(Arc::new(state))
     }
 

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -29,6 +29,7 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
 
     let slack_api = Arc::new(octobot_ops::slack::Slack::new(
         config.slack.bot_token.clone(),
+        config.slack_db_path(),
         metrics.clone(),
     ));
 

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -91,6 +91,7 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
         config.clone(),
         github_api.clone(),
         jira_api.clone(),
+        slack_api.clone(),
         metrics.clone(),
     ));
     let octobot = OctobotService::new(

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -98,7 +98,7 @@ struct SlackMessage {
 pub struct Slack {
     client: Arc<HTTPClient>,
     recent_messages: Mutex<Vec<SlackMessage>>,
-    slack_db: SlackDatabase,
+    slack_db: Mutex<SlackDatabase>,
 }
 
 const TRIM_MESSAGES_AT: usize = 200;
@@ -124,7 +124,7 @@ impl Slack {
         );
         Slack {
             client,
-            slack_db,
+            slack_db: Mutex::new(slack_db),
             recent_messages: Mutex::new(Vec::new()),
         }
     }
@@ -138,17 +138,17 @@ impl Slack {
         initial_thread: bool,
         thread_guid: &str,
     ) {
-        let parent_thread = match self
-            .slack_db
-            .lookup_previous_thread(thread_guid, channel_id)
-            .await
+        let parent_thread;
         {
-            Ok(r) => r,
-            Err(e) => {
-                error!("Error looking up slack thread: {}", e);
-                None
-            }
-        };
+            let slack_db = self.slack_db.lock().unwrap();
+            parent_thread = match slack_db.lookup_previous_thread(thread_guid, channel_id) {
+                Ok(r) => r,
+                Err(e) => {
+                    error!("Error looking up slack thread: {}", e);
+                    None
+                }
+            };
+        }
 
         let slack_msg = SlackMessage {
             text: msg.to_string(),
@@ -174,9 +174,9 @@ impl Slack {
                         channel_name, thread
                     );
                     if initial_thread && !thread_guid.is_empty() && parent_thread.is_none() {
-                        self.slack_db
+                        let slack_db = self.slack_db.lock().unwrap();
+                        slack_db
                             .insert_thread(thread_guid, channel_id, thread.as_str())
-                            .await
                             .ok();
                     }
                 } else {
@@ -329,14 +329,8 @@ pub fn req(
     }
 }
 
-pub fn new_runner(
-    bot_token: String,
-    slack_db_path: String,
-    metrics: Arc<Metrics>,
-) -> Arc<dyn worker::Runner<SlackRequest>> {
-    Arc::new(Runner {
-        slack: Arc::new(Slack::new(bot_token, slack_db_path, metrics)),
-    })
+pub fn new_runner(slack: Arc<Slack>) -> Arc<dyn worker::Runner<SlackRequest>> {
+    Arc::new(Runner { slack })
 }
 
 #[async_trait::async_trait]

--- a/ops/src/slack.rs
+++ b/ops/src/slack.rs
@@ -105,7 +105,9 @@ const TRIM_MESSAGES_AT: usize = 200;
 const TRIM_MESSAGES_TO: usize = 20;
 
 impl Slack {
-    pub fn new(bot_token: String, metrics: Arc<Metrics>) -> Slack {
+    pub fn new(bot_token: String, slack_db_path: String, metrics: Arc<Metrics>) -> Slack {
+        let slack_db = SlackDatabase::new(&slack_db_path).expect("init slack db");
+
         let mut headers = reqwest::header::HeaderMap::new();
         headers.append(
             reqwest::header::AUTHORIZATION,
@@ -122,8 +124,8 @@ impl Slack {
         );
         Slack {
             client,
+            slack_db,
             recent_messages: Mutex::new(Vec::new()),
-            slack_db: SlackDatabase::new("slack_db.sqlite3").unwrap(),
         }
     }
 
@@ -329,10 +331,11 @@ pub fn req(
 
 pub fn new_runner(
     bot_token: String,
+    slack_db_path: String,
     metrics: Arc<Metrics>,
 ) -> Arc<dyn worker::Runner<SlackRequest>> {
     Arc::new(Runner {
-        slack: Arc::new(Slack::new(bot_token, metrics)),
+        slack: Arc::new(Slack::new(bot_token, slack_db_path, metrics)),
     })
 }
 

--- a/ops/src/slack_db.rs
+++ b/ops/src/slack_db.rs
@@ -25,7 +25,7 @@ impl SlackDatabase {
         self.db.connect()
     }
 
-    pub async fn lookup_previous_thread(
+    pub fn lookup_previous_thread(
         &self,
         thread_guid: &str,
         slack_channel: &str,
@@ -47,7 +47,7 @@ impl SlackDatabase {
         Ok(thread)
     }
 
-    pub async fn insert_thread(
+    pub fn insert_thread(
         &self,
         thread_guid: &str,
         slack_channel: &str,


### PR DESCRIPTION
Because there were multiple slack dbs trying to be initialized at the same time, they 
were racing on the schema migration. There should only be a single db instance.

Also: expect sqlite db to be in the config dir, not the working dir.