### PR TITLE
Add option to mute team direct messages

### DIFF
--- a/lib/src/config_db_migrations.rs
+++ b/lib/src/config_db_migrations.rs
@@ -71,6 +71,7 @@ pub fn all_migrations() -> Vec<Box<dyn Migration>> {
         sql(r#"alter table users add column email varchar not null default ''"#),
         sql(r#"alter table repos add column use_threads tinyint not null default 1"#),
         sql(r#"alter table users add column muted_repos varchar not null default ''"#),
+        sql(r#"alter table users add column mute_team_dm tinyint not null default 0"#),
     ]
 }
 

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -112,9 +112,10 @@ impl UserConfig {
         repo_full_name: &String,
     ) -> Option<SlackRecipient> {
         self.lookup_info(github_name).and_then(|u| {
-            if u.mute_direct_messages || u.muted_repos.contains(repo_full_name) {
-                None
-            } else if for_team_reference && u.mute_team_direct_messages {
+            if u.mute_direct_messages
+                || u.muted_repos.contains(repo_full_name)
+                || (for_team_reference && u.mute_team_direct_messages)
+            {
                 None
             } else if !u.slack_id.is_empty() {
                 Some(SlackRecipient::new(&u.slack_id, &u.slack_name))

--- a/lib/src/users.rs
+++ b/lib/src/users.rs
@@ -16,6 +16,7 @@ pub struct UserInfo {
     pub slack_id: String,
     pub email: String,
     pub mute_direct_messages: bool,
+    pub mute_team_direct_messages: bool,
     pub muted_repos: Vec<String>,
 }
 
@@ -39,6 +40,7 @@ impl UserInfo {
             slack_id: slack_id.to_string(),
             email: email.to_string(),
             mute_direct_messages: false,
+            mute_team_direct_messages: false,
             muted_repos,
         }
     }
@@ -56,7 +58,7 @@ impl UserConfig {
     pub fn insert_info(&mut self, user: &UserInfo) -> Result<()> {
         let conn = self.db.connect()?;
         conn.execute(
-            "INSERT INTO users (github_name, slack_name, slack_id, email, mute_direct_messages, muted_repos) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO users (github_name, slack_name, slack_id, email, mute_direct_messages, muted_repos, mute_team_dm) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             [
                 &user.github,
                 &user.slack_name,
@@ -64,6 +66,7 @@ impl UserConfig {
                 &user.email,
                 &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql,
                 &user.muted_repos.join(","),
+                &db::to_tinyint(user.mute_team_direct_messages) as &dyn ToSql,
             ],
         )
         .map_err(|e| anyhow!("Error inserting user {}: {}", user.github, e))?;
@@ -74,8 +77,17 @@ impl UserConfig {
     pub fn update(&mut self, user: &UserInfo) -> Result<()> {
         let conn = self.db.connect()?;
         conn.execute(
-            "UPDATE users set github_name = ?1, slack_name = ?2, slack_id = ?3, email = ?4, mute_direct_messages = ?5, muted_repos = ?6  where id = ?7",
-            [&user.github, &user.slack_name, &user.slack_id, &user.email, &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql, &user.muted_repos.join(","), &user.id],
+            "UPDATE users set github_name = ?1, slack_name = ?2, slack_id = ?3, email = ?4, mute_direct_messages = ?5, muted_repos = ?6, mute_team_dm = ?8  where id = ?7",
+            [
+                &user.github,
+                &user.slack_name,
+                &user.slack_id,
+                &user.email,
+                &db::to_tinyint(user.mute_direct_messages) as &dyn ToSql,
+                &user.muted_repos.join(","),
+                &user.id,
+                &db::to_tinyint(user.mute_team_direct_messages) as &dyn ToSql
+            ],
         ).map_err(|e| anyhow!("Error updating user {}: {}", user.github, e))?;
 
         Ok(())
@@ -96,10 +108,13 @@ impl UserConfig {
     pub fn slack_direct_message(
         &self,
         github_name: &str,
+        for_team_reference: bool,
         repo_full_name: &String,
     ) -> Option<SlackRecipient> {
         self.lookup_info(github_name).and_then(|u| {
             if u.mute_direct_messages || u.muted_repos.contains(repo_full_name) {
+                None
+            } else if for_team_reference && u.mute_team_direct_messages {
                 None
             } else if !u.slack_id.is_empty() {
                 Some(SlackRecipient::new(&u.slack_id, &u.slack_name))
@@ -112,7 +127,7 @@ impl UserConfig {
     pub fn get_all(&self) -> Result<Vec<UserInfo>> {
         let conn = self.db.connect()?;
         let mut stmt = conn.prepare(
-            "SELECT id, slack_name, slack_id, email, github_name, mute_direct_messages, muted_repos FROM users ORDER BY github_name",
+            "SELECT id, slack_name, slack_id, email, github_name, mute_direct_messages, muted_repos, mute_team_dm FROM users ORDER BY github_name",
         )?;
         let found = stmt.query_map([], |row| {
             Ok(UserInfo {
@@ -122,6 +137,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: row.get(4)?,
                 mute_direct_messages: db::to_bool(row.get(5)?),
+                mute_team_direct_messages: db::to_bool(row.get(7)?),
                 muted_repos: row
                     .get::<usize, String>(6)?
                     .split(',')
@@ -153,7 +169,7 @@ impl UserConfig {
         let github_name = github_name.to_string();
         let conn = self.db.connect()?;
         let mut stmt = conn.prepare(
-            "SELECT id, slack_name, slack_id, email, mute_direct_messages, muted_repos FROM users where github_name = ?1",
+            "SELECT id, slack_name, slack_id, email, mute_direct_messages, muted_repos, mute_team_dm FROM users where github_name = ?1",
         )?;
         let found = stmt.query_map([&github_name], |row| {
             Ok(UserInfo {
@@ -163,6 +179,7 @@ impl UserConfig {
                 email: row.get(3)?,
                 github: github_name.clone(),
                 mute_direct_messages: db::to_bool(row.get(4)?),
+                mute_team_direct_messages: db::to_bool(row.get(6)?),
                 muted_repos: row
                     .get::<usize, String>(5)?
                     .split(',')
@@ -195,7 +212,10 @@ mod tests {
         let (users, _temp) = new_test();
 
         assert_eq!(None, users.slack_user_name("joe"));
-        assert_eq!(None, users.slack_direct_message("joe", &"org/repo".into()));
+        assert_eq!(
+            None,
+            users.slack_direct_message("joe", false, &"org/repo".into())
+        );
     }
 
     #[test]
@@ -210,12 +230,12 @@ mod tests {
         );
         assert_eq!(
             Some(SlackRecipient::new("@the-slacker", "the-slacker")),
-            users.slack_direct_message("some-git-user", &"org/repo".into())
+            users.slack_direct_message("some-git-user", false, &"org/repo".into())
         );
         assert_eq!(None, users.slack_user_name("some.other.user"));
         assert_eq!(
             None,
-            users.slack_direct_message("some.other.user", &"org/repo".into())
+            users.slack_direct_message("some.other.user", false, &"org/repo".into())
         );
     }
 
@@ -232,7 +252,7 @@ mod tests {
         );
         assert_eq!(
             Some(SlackRecipient::new("1234", "the-slacker")),
-            users.slack_direct_message("some-git-user", &"org/repo".into())
+            users.slack_direct_message("some-git-user", false, &"org/repo".into())
         );
     }
 
@@ -256,11 +276,11 @@ mod tests {
 
         assert_eq!(
             None,
-            users.slack_direct_message("some-git-user", &"org1/repo1".into())
+            users.slack_direct_message("some-git-user", false, &"org1/repo1".into())
         );
         assert_eq!(
             Some(SlackRecipient::new("1234", "the-slacker")),
-            users.slack_direct_message("some-git-user", &"org1/repo3".into())
+            users.slack_direct_message("some-git-user", false, &"org1/repo3".into())
         );
     }
 }

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -242,6 +242,7 @@ app.controller('UsersController', function($scope, sessionHttp, notificationServ
   $scope.addUser = function() {
     $scope.theUser = {
       mute_direct_messages: false,
+      mute_team_direct_messages: false,
       muted_repos: [],
     };
     $('#add-user-modal').modal('show');

--- a/octobot/src/assets/users.html
+++ b/octobot/src/assets/users.html
@@ -41,6 +41,11 @@
               <input type="checkbox" ng-model="theUser.mute_direct_messages"> Mute Direct Messages
             </label>
           </div>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" ng-model="theUser.mute_team_direct_messages"> Mute Team Direct Messages
+            </label>
+          </div>
           <div class="form-group">
             <input type="text" class="form-control" ng-model="theUser.muted_repos" ng-list placeholder="muted repos">
           </div>

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -524,7 +524,7 @@ impl GithubEventHandler {
             reviewer_names.extend(self.slack_user_names(reviewers));
         }
         if let Some(ref teams) = pull_request.requested_teams {
-            reviewer_names.extend(teams.into_iter().map(|t| format!("@{}", t.slug)));
+            reviewer_names.extend(teams.iter().map(|t| format!("@{}", t.slug)));
         }
 
         reviewer_names

--- a/octobot/src/server/github_handler.rs
+++ b/octobot/src/server/github_handler.rs
@@ -18,7 +18,7 @@ use octobot_lib::jira;
 use octobot_lib::metrics::{self, Metrics};
 use octobot_ops::force_push::{self, ForcePushRequest};
 use octobot_ops::git_clone_manager::GitCloneManager;
-use octobot_ops::messenger::{self, Messenger};
+use octobot_ops::messenger::{self, Messenger, Participants};
 use octobot_ops::pr_merge::{self, PRMergeRequest};
 use octobot_ops::repo_version::{self, RepoVersionRequest};
 use octobot_ops::slack::{self, Slack, SlackAttachmentBuilder, SlackRequest};
@@ -455,23 +455,27 @@ impl GithubEventHandler {
         &self,
         pull_request: &dyn github::PullRequestLike,
         pr_commits: &[github::Commit],
-    ) -> Vec<github::User> {
+    ) -> Participants {
+        let mut participants = Participants::new();
+
         // start with the assignees
-        let mut participants = pull_request.assignees();
+        for u in pull_request.assignees().into_iter() {
+            participants.add_user(u);
+        }
         // add the author of the PR
-        participants.push(pull_request.user().clone());
+        participants.add_user(pull_request.user().clone());
         // add team participants
-        participants.extend(self.team_participants(pull_request).await);
+        for u in self.team_participants(pull_request).await {
+            participants.add_team_member(u);
+        }
 
         // look up commits and add the authors of those
         for commit in pr_commits {
             if let Some(ref author) = commit.author {
-                participants.push(author.clone());
+                participants.add_user(author.clone());
             }
         }
 
-        participants.sort_by(|a, b| a.login().cmp(b.login()));
-        participants.dedup();
         participants
     }
 
@@ -628,7 +632,7 @@ impl GithubEventHandler {
                             &pull_request.user,
                             &self.data.sender,
                             &self.repository,
-                            &self.all_participants(&pull_request, &commits).await,
+                            self.all_participants(&pull_request, &commits).await,
                             branch_name,
                             &commits,
                             vec![thread_guid],
@@ -771,7 +775,7 @@ impl GithubEventHandler {
 
                     let mut participants = self.all_participants(&pull_request, &commits).await;
                     for username in util::get_mentioned_usernames(review.body()) {
-                        participants.push(github::User::new(username))
+                        participants.add_user(github::User::new(username));
                     }
 
                     self.messenger.send_to_all(
@@ -780,7 +784,7 @@ impl GithubEventHandler {
                         &pull_request.user,
                         &self.data.sender,
                         &self.repository,
-                        &participants,
+                        participants,
                         branch_name,
                         &commits,
                         vec![self.build_thread_guid(pull_request.number)],
@@ -830,7 +834,7 @@ impl GithubEventHandler {
 
         let mut participants = self.all_participants(pull_request, commits).await;
         for username in util::get_mentioned_usernames(comment.body()) {
-            participants.push(github::User::new(username))
+            participants.add_user(github::User::new(username));
         }
 
         self.messenger.send_to_all(
@@ -839,7 +843,7 @@ impl GithubEventHandler {
             pull_request.user(),
             &self.data.sender,
             &self.repository,
-            &participants,
+            participants,
             branch_name,
             commits,
             vec![self.build_thread_guid(pull_request.number())],
@@ -904,7 +908,7 @@ impl GithubEventHandler {
                         &comment.user,
                         &self.data.sender,
                         &self.repository,
-                        &[],
+                        Participants::new(),
                         branch_name,
                         &commits,
                         thread_guids,
@@ -1040,7 +1044,7 @@ impl GithubEventHandler {
                             &pull_request.user,
                             &self.data.sender,
                             &self.repository,
-                            &self.all_participants(&pull_request, &commits).await,
+                            self.all_participants(&pull_request, &commits).await,
                             &branch_name,
                             &commits,
                             vec![self.build_thread_guid(pull_request.number)],

--- a/octobot/tests/github_handler_test.rs
+++ b/octobot/tests/github_handler_test.rs
@@ -494,13 +494,6 @@ async fn test_issue_comment() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -509,6 +502,13 @@ async fn test_issue_comment() {
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -553,13 +553,6 @@ async fn test_pull_request_comment() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -575,6 +568,13 @@ async fn test_pull_request_comment() {
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -618,13 +618,6 @@ async fn test_pull_request_review_commented() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -640,6 +633,13 @@ async fn test_pull_request_review_commented() {
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -750,13 +750,6 @@ async fn test_pull_request_review_approved() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -772,6 +765,13 @@ async fn test_pull_request_review_approved() {
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -816,13 +816,6 @@ async fn test_pull_request_review_changes_requested() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -838,6 +831,13 @@ async fn test_pull_request_review_changes_requested() {
         ),
         slack::req(
             SlackRecipient::user_mention("mentioned.participant"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -902,13 +902,6 @@ async fn test_pull_request_closed() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -924,6 +917,13 @@ async fn test_pull_request_closed() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -988,13 +988,6 @@ async fn test_pull_request_ready_for_review() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1010,6 +1003,13 @@ async fn test_pull_request_ready_for_review() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1082,13 +1082,6 @@ async fn test_pull_request_assigned() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1111,6 +1104,13 @@ async fn test_pull_request_assigned() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1178,13 +1178,6 @@ async fn test_pull_request_review_requested() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1226,6 +1219,13 @@ async fn test_pull_request_review_requested() {
             None,
             false,
         ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
     ]);
 
     let resp = test.handler.handle_event().await.unwrap();
@@ -1262,13 +1262,6 @@ async fn test_pull_request_review_no_username() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1277,6 +1270,13 @@ async fn test_pull_request_review_no_username() {
         ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1359,13 +1359,6 @@ async fn test_pull_request_merged_error_getting_labels() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg1,
-            &attach1,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg1,
             &attach1,
@@ -1381,6 +1374,13 @@ async fn test_pull_request_merged_error_getting_labels() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg1,
+            &attach1,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg1,
             &attach1,
             None,
@@ -1436,13 +1436,6 @@ async fn test_pull_request_merged_no_labels() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1458,6 +1451,13 @@ async fn test_pull_request_merged_no_labels() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1509,13 +1509,6 @@ async fn test_pull_request_merged_backport_labels() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1531,6 +1524,13 @@ async fn test_pull_request_merged_backport_labels() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1618,13 +1618,6 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1640,6 +1633,13 @@ async fn test_pull_request_merged_backport_labels_custom_pattern() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -1835,13 +1835,6 @@ async fn test_push_with_pr() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach1,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach1,
@@ -1863,17 +1856,17 @@ async fn test_push_with_pr() {
             false,
         ),
         slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
+            msg,
+            &attach1,
+            None,
+            false,
+        ),
+        slack::req(
             SlackRecipient::by_name("the-reviews-channel"),
             &format!("{} {}", msg, REPO_MSG),
             &attach2,
             Some("some-user/some-repo/99".to_string()),
-            false,
-        ),
-        slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach2,
-            None,
             false,
         ),
         slack::req(
@@ -1885,6 +1878,13 @@ async fn test_push_with_pr() {
         ),
         slack::req(
             SlackRecipient::user_mention("bob.author"),
+            msg,
+            &attach2,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach2,
             None,
@@ -1935,13 +1935,6 @@ async fn test_push_force_notify() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -1957,6 +1950,13 @@ async fn test_push_force_notify() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -2034,13 +2034,6 @@ async fn test_push_force_notify_ignored() {
         .build()];
     test.slack.expect(vec![
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -2056,6 +2049,13 @@ async fn test_push_force_notify_ignored() {
         ),
         slack::req(
             SlackRecipient::user_mention("joe.reviewer"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -2097,13 +2097,6 @@ async fn test_team_members_cache() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -2133,6 +2126,13 @@ async fn test_team_members_cache() {
         ),
         slack::req(
             SlackRecipient::user_mention("team.member2"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,
@@ -2159,13 +2159,6 @@ async fn test_team_members_cache() {
             false,
         ),
         slack::req(
-            SlackRecipient::user_mention("the.pr.owner"),
-            msg,
-            &attach,
-            None,
-            false,
-        ),
-        slack::req(
             SlackRecipient::user_mention("assign1"),
             msg,
             &attach,
@@ -2195,6 +2188,13 @@ async fn test_team_members_cache() {
         ),
         slack::req(
             SlackRecipient::user_mention("team.member2"),
+            msg,
+            &attach,
+            None,
+            false,
+        ),
+        slack::req(
+            SlackRecipient::user_mention("the.pr.owner"),
             msg,
             &attach,
             None,


### PR DESCRIPTION
This turned out to be a bit tricky to propagate the kind of PR
participation that triggered the direct message.

This also resulted in sorting all participants by login, which caused
some test reorganization.
