### PR TITLE
Redeliver webhooks on startup

### DIFF
--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use log::{error, info};
+use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 use crate::errors::*;
 use crate::github::models::*;
@@ -131,10 +133,15 @@ pub trait Session: Send + Sync {
         run: &CheckRun,
     ) -> Result<()>;
     async fn get_team_members(&self, repo: &Repo, id: u32) -> Result<Vec<User>>;
+
+    // webhoook
+    async fn get_webhook_deliveries_since(&self, guid: &str) -> Result<Vec<WebhookDelivery>>;
+    async fn redeliver_webhook(&self, id: u32) -> Result<()>;
 }
 
 #[async_trait]
 pub trait GithubSessionFactory: Send + Sync {
+    async fn new_service_session(&self) -> Result<GithubSession>;
     async fn new_session(&self, owner: &str, repo: &str) -> Result<GithubSession>;
     async fn get_token_org(&self, org: &str) -> Result<String>;
     async fn get_token_repo(&self, owner: &str, repo: &str) -> Result<String>;
@@ -221,17 +228,18 @@ impl GithubApp {
         let client = self.new_client()?;
 
         // All we care about for now is the installation id
-        #[derive(Deserialize)]
+        #[derive(Deserialize, Debug)]
         struct Installation {
             id: u32,
         }
+
         #[derive(Deserialize)]
         struct AccessToken {
             token: String,
         }
 
-        // Lookup the installation id for this org/repo
         let installation: Installation = client.get(installation_url).await?;
+
         // Get a new access token for this id
         let token: AccessToken = client
             .post(
@@ -266,6 +274,17 @@ impl GithubSessionFactory for GithubApp {
             &self.host,
             &self.bot_name(),
             &self.get_token_repo(owner, repo).await?,
+            Some(self.app_id),
+            self.metrics.clone(),
+        )
+    }
+
+    async fn new_service_session(&self) -> Result<GithubSession> {
+        let jwt_token = jwt::new_token(self.app_id, &self.app_key);
+        GithubSession::new(
+            &self.host,
+            &self.bot_name(),
+            &jwt_token,
             Some(self.app_id),
             self.metrics.clone(),
         )
@@ -327,6 +346,10 @@ impl GithubSessionFactory for GithubOauthApp {
             self.metrics.clone(),
         )
     }
+
+    async fn new_service_session(&self) -> Result<GithubSession> {
+        return self.new_session("", "").await;
+    }
 }
 
 pub struct GithubSession {
@@ -365,7 +388,7 @@ impl GithubSession {
         );
         headers.insert(
             reqwest::header::AUTHORIZATION,
-            format!("Token {}", token).parse().unwrap(),
+            format!("Bearer {}", token).parse().unwrap(),
         );
 
         let client = HTTPClient::new_with_headers(&api_base(host), headers)?;
@@ -978,5 +1001,96 @@ impl Session for GithubSession {
                     e
                 )
             })
+    }
+
+    async fn get_webhook_deliveries_since(&self, guid: &str) -> Result<Vec<WebhookDelivery>> {
+        if self.app_id.is_none() {
+            bail!("Only supported for GitHub Apps");
+        }
+
+        let mut next_cursor = None;
+
+        let mut result = vec![];
+
+        loop {
+            let mut url = String::from("/app/hook/deliveries?per_page=100");
+            if let Some(next_cursor) = next_cursor {
+                url += &format!("&cursor={}", next_cursor);
+            }
+
+            let res = self.client.get_raw(&url).await?;
+            next_cursor = parse_next_cursor(&res);
+
+            if next_cursor.is_none() {
+                break;
+            }
+
+            let results: Vec<WebhookDelivery> = self.client.parse_json(res).await?;
+
+            let done = results.iter().any(|d| d.guid == guid);
+
+            result.extend(results.into_iter());
+
+            if done {
+                break;
+            }
+        }
+
+        return Ok(result);
+    }
+
+    async fn redeliver_webhook(&self, id: u32) -> Result<()> {
+        if self.app_id.is_none() {
+            bail!("Only supported for GitHub Apps");
+        }
+        let body: Option<&String> = None;
+
+        self.client
+            .post_void_opt(&format!("/app/hook/deliveries/{}/attempts", id), body)
+            .await
+    }
+}
+
+fn parse_link_header(value: &str) -> HashMap<String, String> {
+    let re = Regex::new(r#"(<([^>]+)>; rel="(\w+)")"#).unwrap();
+    let mut result = HashMap::new();
+
+    for c in re.captures_iter(&value) {
+        result.insert(c[3].into(), c[2].into());
+    }
+
+    return result;
+}
+
+fn parse_next_cursor(res: &reqwest::Response) -> Option<String> {
+    if let Some(ref value) = res.headers().get(reqwest::header::LINK) {
+        let values = parse_link_header(value.to_str().unwrap_or(""));
+        if let Some(ref next) = values.get("next") {
+            if let Ok(url) = url::Url::parse(next) {
+                for (key, value) in url.query_pairs() {
+                    if key == "cursor" {
+                        return Some(value.into_owned());
+                    }
+                }
+            }
+        }
+    }
+    return None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_link() {
+        let link1 = r#"<https://git.example.com/?per_page=1&cursor=A>; rel="next""#;
+
+        let parsed = parse_link_header(link1);
+        assert_eq!(1, parsed.len());
+        assert_eq!(
+            "https://git.example.com/?per_page=1&cursor=A",
+            parsed.get("next").unwrap()
+        );
     }
 }

--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -1070,17 +1070,17 @@ fn parse_link_header(value: &str) -> HashMap<String, String> {
     let re = Regex::new(r#"(<([^>]+)>; rel="(\w+)")"#).unwrap();
     let mut result = HashMap::new();
 
-    for c in re.captures_iter(&value) {
+    for c in re.captures_iter(value) {
         result.insert(c[3].into(), c[2].into());
     }
 
-    return result;
+    result
 }
 
 fn parse_next_cursor(res: &reqwest::Response) -> Option<String> {
-    if let Some(ref value) = res.headers().get(reqwest::header::LINK) {
+    if let Some(value) = res.headers().get(reqwest::header::LINK) {
         let values = parse_link_header(value.to_str().unwrap_or(""));
-        if let Some(ref next) = values.get("next") {
+        if let Some(next) = values.get("next") {
             if let Ok(url) = url::Url::parse(next) {
                 for (key, value) in url.query_pairs() {
                     if key == "cursor" {
@@ -1090,7 +1090,8 @@ fn parse_next_cursor(res: &reqwest::Response) -> Option<String> {
             }
         }
     }
-    return None;
+
+    None
 }
 
 #[cfg(test)]

--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -716,6 +716,15 @@ impl DismissedReview {
     }
 }
 
+#[derive(Deserialize, Debug)]
+pub struct WebhookDelivery {
+    pub id: u32,
+    pub guid: String,
+    pub redelivery: bool,
+    pub status_code: u32,
+    pub delivered_at: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/http_client.rs
+++ b/lib/src/http_client.rs
@@ -253,7 +253,7 @@ impl HTTPClient {
                 self.maybe_record_status("<invalid json>");
                 let err: Result<()> = self.make_clean_err(e);
                 bail!(
-                    "Invalid JSONL: {}. Response body: {}",
+                    "Invalid JSON: {}. Response body: {}",
                     err.unwrap_err(),
                     text
                 );

--- a/lib/src/http_client.rs
+++ b/lib/src/http_client.rs
@@ -132,7 +132,7 @@ impl HTTPClient {
 
     pub async fn post_void_opt<U: Serialize>(&self, path: &str, body: Option<&U>) -> Result<()> {
         let _timer = self.maybe_start_timer("post", path);
-        let res = self.client.post(&self.make_url(path));
+        let res = self.client.post(self.make_url(path));
         let res = match body {
             None => res,
             Some(body) => res.json(body),

--- a/lib/src/jwt.rs
+++ b/lib/src/jwt.rs
@@ -21,7 +21,7 @@ pub fn new_token(app_id: u32, app_key_der: &[u8]) -> String {
         iss: app_id.to_string(),
     };
 
-    let key = EncodingKey::from_rsa_der(app_key_der);
+    let key = EncodingKey::from_rsa_pem(app_key_der).unwrap();
 
     jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, &key).unwrap()
 }

--- a/lib/src/jwt.rs
+++ b/lib/src/jwt.rs
@@ -21,7 +21,7 @@ pub fn new_token(app_id: u32, app_key_der: &[u8]) -> String {
         iss: app_id.to_string(),
     };
 
-    let key = EncodingKey::from_rsa_pem(app_key_der).unwrap();
+    let key = EncodingKey::from_rsa_der(app_key_der);
 
     jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, &key).unwrap()
 }

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -187,6 +187,6 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
     }
 
     if let Err(e) = webhook_redeliver.await {
-        error!("jobs error: {}", e);
+        error!("webhook redeliver error: {}", e);
     }
 }

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -16,6 +16,8 @@ use octobot_lib::jira;
 use octobot_lib::jira::api::JiraSession;
 use octobot_lib::metrics;
 
+use octobot_lib::github::api::Session;
+
 pub fn start(config: Config) {
     let num_http_threads = config.main.num_http_threads.unwrap_or(20);
     let metrics = metrics::Metrics::new();
@@ -73,6 +75,11 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
         }
     };
 
+    let webhook_db = Arc::new(WebhookDatabase::new(&config.webhook_db_path()).expect("webhook db"));
+    let latest_webhook_guid = webhook_db
+        .get_latest_guid()
+        .expect("failed to lookup latest guid");
+
     let jira_api: Option<Arc<dyn jira::api::Session>> = if let Some(ref jira_config) = config.jira {
         match JiraSession::new(jira_config, Some(metrics.clone())).await {
             Ok(s) => Some(Arc::new(s)),
@@ -86,8 +93,6 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
         Some(ref addr_and_port) => addr_and_port.parse().unwrap(),
         None => "0.0.0.0:3000".parse().unwrap(),
     };
-
-    let webhook_db = Arc::new(WebhookDatabase::new(&config.webhook_db_path()).expect("webhook db"));
 
     let ui_sessions = Arc::new(Sessions::new());
     let github_handler_state = Arc::new(GithubHandlerState::new(
@@ -141,11 +146,46 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
     let server = Server::bind(&http_addr).serve(main_service);
     info!("Listening (HTTP) on {}", http_addr);
 
+    let webhook_redeliver = tokio::spawn(async move {
+        if let Some(guid) = latest_webhook_guid {
+            let session = match github_api.new_service_session().await {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("Failed to get session to redeliver webhooks: {}", e);
+                    return;
+                }
+            };
+
+            let webhooks = match session.get_webhook_deliveries_since(&guid).await {
+                Ok(v) => v,
+                Err(e) => {
+                    log::error!("Failed to lookup webhook deliveries: {}", e);
+                    return;
+                }
+            };
+
+            for d in webhooks {
+                if d.status_code != 200 && d.status_code != 400 {
+                    log::info!("Redelivering webhook guid {} -- {}", d.guid, d.status_code);
+                    if let Err(e) = session.redeliver_webhook(d.id).await {
+                        log::error!("Failed to redleiver webhook guid: {}", e);
+                    }
+                }
+            }
+        } else {
+            log::info!("No recent webhook delivery to search for");
+        }
+    });
+
     if let Err(e) = server.await {
         error!("server error: {}", e);
     }
 
     if let Err(e) = jobs.await {
+        error!("jobs error: {}", e);
+    }
+
+    if let Err(e) = webhook_redeliver.await {
         error!("jobs error: {}", e);
     }
 }

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -156,7 +156,8 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
                 }
             };
 
-            let webhooks = match session.get_webhook_deliveries_since(&guid).await {
+            let max_count = 10_000;
+            let webhooks = match session.get_webhook_deliveries_since(&guid, max_count).await {
                 Ok(v) => v,
                 Err(e) => {
                     log::error!("Failed to lookup webhook deliveries: {}", e);

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -500,7 +500,11 @@ impl Session for MockGithub {
         call.ret
     }
 
-    async fn get_webhook_deliveries_since(&self, guid: &str) -> Result<Vec<WebhookDelivery>> {
+    async fn get_webhook_deliveries_since(
+        &self,
+        guid: &str,
+        max_count: usize,
+    ) -> Result<Vec<WebhookDelivery>> {
         let mut calls = self.get_webhook_deliveries_calls.lock().unwrap();
         assert!(
             calls.len() > 0,
@@ -508,6 +512,7 @@ impl Session for MockGithub {
         );
         let call = calls.remove(0);
         assert_eq!(call.args[0], guid);
+        assert_eq!(call.args[1], max_count.to_string());
 
         call.ret
     }

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -29,6 +29,8 @@ pub struct MockGithub {
     create_check_run_calls: Mutex<Vec<MockCall<u32>>>,
     update_check_run_calls: Mutex<Vec<MockCall<()>>>,
     get_team_members_calls: Mutex<Vec<MockCall<Vec<User>>>>,
+    get_webhook_deliveries_calls: Mutex<Vec<MockCall<Vec<WebhookDelivery>>>>,
+    redeliver_webhook_calls: Mutex<Vec<MockCall<()>>>,
 }
 
 #[derive(Debug)]
@@ -72,6 +74,8 @@ impl MockGithub {
             create_check_run_calls: Mutex::new(vec![]),
             update_check_run_calls: Mutex::new(vec![]),
             get_team_members_calls: Mutex::new(vec![]),
+            get_webhook_deliveries_calls: Mutex::new(vec![]),
+            redeliver_webhook_calls: Mutex::new(vec![]),
         }
     }
 }
@@ -138,6 +142,16 @@ impl Drop for MockGithub {
                 self.get_timeline_calls.lock().unwrap().len() == 0,
                 "Unmet get_timeline calls: {:?}",
                 *self.get_timeline_calls.lock().unwrap()
+            );
+            assert!(
+                self.get_webhook_deliveries_calls.lock().unwrap().len() == 0,
+                "Unmet get_webhook_deliveries calls: {:?}",
+                *self.get_webhook_deliveries_calls.lock().unwrap()
+            );
+            assert!(
+                self.redeliver_webhook_calls.lock().unwrap().len() == 0,
+                "Unmet redeliver_webhook calls: {:?}",
+                *self.redeliver_webhook_calls.lock().unwrap()
             );
         }
     }
@@ -484,6 +498,27 @@ impl Session for MockGithub {
         assert_eq!(call.args[1], team_id.to_string());
 
         call.ret
+    }
+
+    async fn get_webhook_deliveries_since(&self, guid: &str) -> Result<Vec<WebhookDelivery>> {
+        let mut calls = self.get_webhook_deliveries_calls.lock().unwrap();
+        assert!(
+            calls.len() > 0,
+            "Unexpected call to get_webhook_deliveries_since"
+        );
+        let call = calls.remove(0);
+        assert_eq!(call.args[0], guid);
+
+        call.ret
+    }
+
+    async fn redeliver_webhook(&self, id: u32) -> Result<()> {
+        let mut calls = self.redeliver_webhook_calls.lock().unwrap();
+        assert!(calls.len() > 0, "Unexpected call to redeliver_webhook");
+        let call = calls.remove(0);
+        assert_eq!(call.args[0], id.to_string());
+
+        Ok(())
     }
 }
 

--- a/ops/src/webhook_db.rs
+++ b/ops/src/webhook_db.rs
@@ -46,7 +46,6 @@ impl WebhookDatabase {
     }
 
     fn get_guids(connection: &Connection, limit: u32) -> Result<Vec<String>> {
-        // Load some recent history into memory at startup
         let mut stmt = connection.prepare(&format!(
             "SELECT guid FROM processed_webhooks ORDER BY timestamp desc LIMIT {}",
             limit


### PR DESCRIPTION
Since we are now storing webhooks in a database, we can request
redelivery on startup for events that occur while octobot was down
