### PR TITLE
Don't try to redeliver webhooks we know about

### DIFF
--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -147,12 +147,11 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
     info!("Listening (HTTP) on {}", http_addr);
 
     let webhook_redeliver = tokio::spawn(async move {
-        // Wait some time for service to startup before redelivering
-        tokio::time::interval(std::time::Duration::from_secs(10))
-            .tick()
-            .await;
-
         let webhook_db = webhook_db.clone();
+
+        // Wait some time for service to startup before redelivering
+        // Need to do this twice to actually wait)
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         if let Some(guid) = latest_webhook_guid {
             log::info!("Starting webhook redelivery");

--- a/octobot/src/server/main.rs
+++ b/octobot/src/server/main.rs
@@ -150,7 +150,6 @@ async fn run_server(config: Config, metrics: Arc<metrics::Metrics>) {
         let webhook_db = webhook_db.clone();
 
         // Wait some time for service to startup before redelivering
-        // Need to do this twice to actually wait)
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
         if let Some(guid) = latest_webhook_guid {

--- a/ops/src/webhook_db.rs
+++ b/ops/src/webhook_db.rs
@@ -66,7 +66,7 @@ impl WebhookDatabase {
     pub fn maybe_record(&self, guid: &str) -> Result<bool> {
         let mut data = self.data.lock().unwrap();
 
-        if self.has_guid(&data, guid) {
+        if self.do_has_guid(&data, guid) {
             return Ok(false);
         }
 
@@ -92,7 +92,12 @@ impl WebhookDatabase {
         Ok(())
     }
 
-    fn has_guid(&self, data: &Data, guid: &str) -> bool {
+    pub fn has_guid(&self, guid: &str) -> bool {
+        let data = self.data.lock().unwrap();
+        self.do_has_guid(&data, guid)
+    }
+
+    fn do_has_guid(&self, data: &Data, guid: &str) -> bool {
         // check in-memory cache to avoid hiting db for common case
         if data.recent_events.contains(&guid.to_string()) {
             return true;


### PR DESCRIPTION
Sometimes the webhook request times out, which GHE records as an error,
but we received and processed the event correctly.

Also: wait correctly. `interval` always fires the first time.