### PR TITLE
Pin rust version in GHA build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
         profile: minimal
         toolchain: 1.73.0
         override: true
-        components: rustfmt
+        components: rustfmt, clippy
 
     - name: Build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: 1.73.0
         override: true
         components: rustfmt
 


### PR DESCRIPTION
We should run tests against the same version as the Dockerfile
