### PR TITLE
chore(build.py): add cli flag to use podman instead of docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This will result in docker image called `octobot:latest` that you can deploy as 
 * Make sure that whatever path you map `/data` to is a persistent location since this is where configuration is stored.
 * Create a `config.toml` file in this location before deploying (see below).
 
+Using podman? Set OCTOBOT\_CONTAINER\_BUILD\_ENGINE=podman when running build.py
+
 ### Configuration
 
 There is one main config file to know about. Hopefully this examples will be sufficiently explanatory:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This will result in docker image called `octobot:latest` that you can deploy as 
 * Make sure that whatever path you map `/data` to is a persistent location since this is where configuration is stored.
 * Create a `config.toml` file in this location before deploying (see below).
 
-Using podman? Set OCTOBOT\_CONTAINER\_BUILD\_ENGINE=podman when running build.py
+Using podman? use `build.py --use-podman`
 
 ### Configuration
 

--- a/build.py
+++ b/build.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import re
 import shutil
 import subprocess
 
-is_travis = os.environ.get('TRAVIS') is not None
+parser = argparse.ArgumentParser(description='Build Octobot and package in a container')
+parser.add_argument(
+    '--use-podman',
+    action='store_true',
+    help='Use podman to build container instead of docker',
+)
 
-engine = os.environ.get('OCTOBOT_CONTAINER_BUILD_ENGINE', 'docker')
+args = parser.parse_args()
+engine = 'docker'
+if args.use_podman:
+    engine = 'podman'
+
+is_travis = os.environ.get('TRAVIS') is not None
 
 class task:
     def __init__(self, title):

--- a/build.py
+++ b/build.py
@@ -6,6 +6,9 @@ import shutil
 import subprocess
 
 is_travis = os.environ.get('TRAVIS') is not None
+
+engine = os.environ.get('OCTOBOT_CONTAINER_BUILD_ENGINE', 'docker')
+
 class task:
     def __init__(self, title):
         self.title = title
@@ -35,17 +38,17 @@ if os.path.exists(docker_tmp):
 os.makedirs(docker_out)
 
 with task("Dockerfile.build"):
-    run("docker build . -f Dockerfile.build -t octobot:build")
+    run("{} build . -f Dockerfile.build -t octobot:build".format(engine))
 with task("extract_files"):
-    run("docker rm -f extract", ignore_fail=True, quiet=True)
-    run("docker create --name extract octobot:build")
-    run("docker cp extract:/usr/src/app/target/release/octobot {}".format(docker_out))
-    run("docker cp extract:/usr/src/app/target/release/octobot-passwd {}".format(docker_out))
-    run("docker cp extract:/usr/src/app/target/release/octobot-ask-pass {}".format(docker_out))
-    run("docker rm -f extract")
+    run("{} rm -f extract".format(engine), ignore_fail=True, quiet=True)
+    run("{} create --name extract octobot:build".format(engine))
+    run("{} cp extract:/usr/src/app/target/release/octobot {}".format(engine, docker_out))
+    run("{} cp extract:/usr/src/app/target/release/octobot-passwd {}".format(engine, docker_out))
+    run("{} cp extract:/usr/src/app/target/release/octobot-ask-pass {}".format(engine, docker_out))
+    run("{} rm -f extract".format(engine))
     # write out the version file
     commit_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
     with open(os.path.join(docker_out, 'version'), 'wb') as f:
         f.write(commit_hash)
 with task("Dockerfile"):
-    run("docker build . -t octobot:latest")
+    run("{} build . -t octobot:latest".format(engine))


### PR DESCRIPTION
podman's cli is arg-compatible with docker, at least for building images. We can allow users to specify use of podman.