### PR TITLE
feat(merge-versions): display link to target version

### DIFF
--- a/lib/src/jira/models.rs
+++ b/lib/src/jira/models.rs
@@ -80,9 +80,13 @@ pub struct Version {
 
 impl Version {
     pub fn new(name: &str) -> Version {
+        Version::with_id(name, "some-id")
+    }
+
+    pub fn with_id(name: &str, id: &str) -> Version {
         Version {
-            uri: "http://something/version/some-id".into(),
-            id: "some-id".into(),
+            uri: format!("http://something/version/{}", id),
+            id: id.into(),
             name: name.into(),
         }
     }

--- a/lib/src/jira/workflow.rs
+++ b/lib/src/jira/workflow.rs
@@ -388,10 +388,10 @@ pub async fn merge_pending_versions(
         }
     }
 
-    return Ok(version::MergedVersion {
+    Ok(version::MergedVersion {
         issues: all_relevant_versions,
         version_id: Some(id),
-    });
+    })
 }
 
 fn find_relevant_versions(

--- a/lib/src/version.rs
+++ b/lib/src/version.rs
@@ -1,4 +1,5 @@
 use std::cmp::{self, Ordering};
+use std::collections::HashMap;
 use std::fmt;
 
 use serde::ser::{Serialize, Serializer};
@@ -6,6 +7,12 @@ use serde::ser::{Serialize, Serializer};
 #[derive(Clone, Debug)]
 pub struct Version {
     parts: Vec<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MergedVersion {
+    pub issues: HashMap<String, Vec<Version>>,
+    pub version_id: Option<String>,
 }
 
 impl Version {

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -502,7 +502,7 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
       $scope.reset();
       $scope.lastResp = resp.data.versions;
       $scope.lastVersion = version;
-      $scope.versionUrl = jiraBase + "/projects/" + project + "/versions/" + resp.data.version_id;
+      $scope.versionUrl = resp.data.version_url;
 
     }).catch(function(e) {
       notificationService.showError('Error creating new version: ' + parseError(e));

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -474,7 +474,7 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
         $scope.req.admin_user = loggedInUser() + resp.data.login_suffix;
       }
       if (resp.data.error) {
-        notificationService.showError(resp.data.error);
+        throw(resp.data.error)
       }
       return resp;
     }).finally(function(e) {

--- a/octobot/src/assets/app.js
+++ b/octobot/src/assets/app.js
@@ -496,11 +496,13 @@ app.controller('VersionsController', function($rootScope, $scope, sessionHttp, n
 
   function mergeVersionsForReal() {
     let version = $scope.req.version;
+    let project = $scope.req.project;
     mergeVersions(false).then(function(resp) {
-      notificationService.showSuccess('Created new version succesfully');
+      notificationService.showSuccess('Created new version succesfully.');
       $scope.reset();
       $scope.lastResp = resp.data.versions;
       $scope.lastVersion = version;
+      $scope.versionUrl = jiraBase + "/projects/" + project + "/versions/" + resp.data.version_id;
 
     }).catch(function(e) {
       notificationService.showError('Error creating new version: ' + parseError(e));

--- a/octobot/src/assets/versions.html
+++ b/octobot/src/assets/versions.html
@@ -48,7 +48,7 @@
   <h3>Success!</h3>
 
   <p>
-    The following JIRAs were found with pending versions were migrated to {{lastVersion}}
+    The following JIRAs were found with pending versions were migrated to <a ng-href="{{versionUrl}}" target="_blank">{{lastVersion}}</a>
   </p>
   <div class="well" ng-repeat="(key, versions) in lastResp">
     <h4><a ng-href="{{jiraLink(key)}}" target="_blank">{{key}}</a></h4>

--- a/octobot/src/server/admin.rs
+++ b/octobot/src/server/admin.rs
@@ -351,13 +351,12 @@ impl MergeVersions {
             }
         }
 
-        let version_url = if let Some(id) = all_relevant_versions.version_id {
-            Some(format!(
+        let version_url = match all_relevant_versions.version_id {
+            Some(id) => Some(format!(
                 "{}/projects/{}/versions/{}",
                 resp.jira_base, &merge_req.project, id
-            ))
-        } else {
-            None
+            )),
+            None => None,
         };
 
         self.make_resp(

--- a/octobot/src/server/admin.rs
+++ b/octobot/src/server/admin.rs
@@ -252,7 +252,7 @@ struct MergeVersionsResp {
     jira_base: String,
     login_suffix: Option<String>,
     versions: HashMap<String, Vec<version::Version>>,
-    version_id: Option<String>,
+    version_url: Option<String>,
     error: Option<String>,
 }
 
@@ -262,7 +262,7 @@ impl MergeVersionsResp {
             jira_base: jira_config.base_url(),
             login_suffix: jira_config.login_suffix.clone(),
             versions: HashMap::new(),
-            version_id: None,
+            version_url: None,
             error: None,
         }
     }
@@ -272,8 +272,8 @@ impl MergeVersionsResp {
         self
     }
 
-    fn set_version_id(mut self, version_id: Option<String>) -> Self {
-        self.version_id = version_id;
+    fn set_version_url(mut self, version_url: Option<String>) -> Self {
+        self.version_url = version_url;
         self
     }
 
@@ -351,9 +351,18 @@ impl MergeVersions {
             }
         }
 
+        let version_url = if let Some(id) = all_relevant_versions.version_id {
+            Some(format!(
+                "{}/projects/{}/versions/{}",
+                resp.jira_base, &merge_req.project, id
+            ))
+        } else {
+            None
+        };
+
         self.make_resp(
             resp.set_versions(all_relevant_versions.issues)
-                .set_version_id(all_relevant_versions.version_id),
+                .set_version_url(version_url),
         )
     }
 

--- a/octobot/src/server/admin.rs
+++ b/octobot/src/server/admin.rs
@@ -344,7 +344,7 @@ impl MergeVersions {
             }
         }
 
-        self.make_resp(resp.set_versions(all_relevant_versions))
+        self.make_resp(resp.set_versions(all_relevant_versions.issues))
     }
 
     fn make_resp(&self, resp: MergeVersionsResp) -> Response<Body> {

--- a/octobot/src/server/admin.rs
+++ b/octobot/src/server/admin.rs
@@ -252,6 +252,7 @@ struct MergeVersionsResp {
     jira_base: String,
     login_suffix: Option<String>,
     versions: HashMap<String, Vec<version::Version>>,
+    version_id: Option<String>,
     error: Option<String>,
 }
 
@@ -261,12 +262,18 @@ impl MergeVersionsResp {
             jira_base: jira_config.base_url(),
             login_suffix: jira_config.login_suffix.clone(),
             versions: HashMap::new(),
+            version_id: None,
             error: None,
         }
     }
 
     fn set_versions(mut self, versions: HashMap<String, Vec<version::Version>>) -> Self {
         self.versions = versions;
+        self
+    }
+
+    fn set_version_id(mut self, version_id: Option<String>) -> Self {
+        self.version_id = version_id;
         self
     }
 
@@ -344,7 +351,10 @@ impl MergeVersions {
             }
         }
 
-        self.make_resp(resp.set_versions(all_relevant_versions.issues))
+        self.make_resp(
+            resp.set_versions(all_relevant_versions.issues)
+                .set_version_id(all_relevant_versions.version_id),
+        )
     }
 
     fn make_resp(&self, resp: MergeVersionsResp) -> Response<Body> {

--- a/octobot/tests/mocks/mock_jira.rs
+++ b/octobot/tests/mocks/mock_jira.rs
@@ -12,7 +12,7 @@ pub struct MockJira {
     get_transitions_calls: Mutex<Vec<MockCall<Vec<Transition>>>>,
     transition_issue_calls: Mutex<Vec<MockCall<()>>>,
     comment_issue_calls: Mutex<Vec<MockCall<()>>>,
-    add_version_calls: Mutex<Vec<MockCall<()>>>,
+    add_version_calls: Mutex<Vec<MockCall<Version>>>,
     get_versions_calls: Mutex<Vec<MockCall<Vec<Version>>>>,
     assign_fix_version_calls: Mutex<Vec<MockCall<()>>>,
     reorder_version_calls: Mutex<Vec<MockCall<()>>>,
@@ -155,7 +155,7 @@ impl Session for MockJira {
         call.ret
     }
 
-    async fn add_version(&self, proj: &str, version: &str) -> Result<()> {
+    async fn add_version(&self, proj: &str, version: &str) -> Result<Version> {
         let mut calls = self.add_version_calls.lock().unwrap();
         assert!(calls.len() > 0, "Unexpected call to add_version");
         let call = calls.remove(0);
@@ -267,7 +267,7 @@ impl MockJira {
             .push(MockCall::new(ret, vec![key, comment]));
     }
 
-    pub fn mock_add_version(&self, proj: &str, version: &str, ret: Result<()>) {
+    pub fn mock_add_version(&self, proj: &str, version: &str, ret: Result<Version>) {
         self.add_version_calls
             .lock()
             .unwrap()


### PR DESCRIPTION
As a user of the octobot version page, I often want to copy a link
to the project version I have just created, in order to paste that
link into other work tracking tools.

This change adds a link to the newly-created version in the success
message, or adds a link to the previously-existing version if it already
existed.

Also: we were previously showing the "Success: ..." message even when
the merge-versions request failed. Now we do not transition to the success
message in error cases.