### PR TITLE
fix: Use newer rusqlite with bundled sqlite library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -334,14 +328,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown",
 ]
@@ -526,10 +519,11 @@ checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1065,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.4.1",
  "fallible-iterator",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,7 +15,7 @@ conventional = "0.5.0"
 log = "0.4.19"
 regex = "1.9.3"
 ring = "0.16.20"
-rusqlite = "0.29.0"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
 serde = "1.0.183"
 serde_derive = "1.0.183"
 serde_json = "1.0.104"

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -22,7 +22,7 @@ unidiff = "0.3.3"
 reqwest = { version = "0.11.18", features = ["json"] }
 async-trait = "0.1.72"
 serde_json = "1.0.104"
-rusqlite = "0.29.0"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
 anyhow = { version = "1.0.72", features = ["backtrace"] }
 
 [dev-dependencies]


### PR DESCRIPTION
To make it easier to build on windows, etc, use bundled sqlite with rusqlite. Apparently may slow things down by not using the system sqlite, but nothing that octobot does should be too affected by that.