### PR TITLE
Update rust for newer cargo version

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,7 +19,7 @@ RUN apt-get update \
   && rm -fr /var/lib/apt/lists/
 
 ENV PATH $PATH:/root/.cargo/bin
-ENV RUST_VERSION 1.73.0
+ENV RUST_VERSION 1.84.1
 
 # install rust
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain "$RUST_VERSION" \


### PR DESCRIPTION
We are mainly controlling the rust version now with rust-toolchain.toml but this older version is failing to read the Cargo.lock file