### PR TITLE
Add get_pull_request_files github API.

### DIFF
--- a/lib/src/github/api.rs
+++ b/lib/src/github/api.rs
@@ -36,6 +36,12 @@ pub trait Session: Send + Sync {
         commit: &str,
         head: Option<&str>,
     ) -> Result<Vec<PullRequest>>;
+    async fn get_pull_request_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+    ) -> Result<Vec<PullRequestFile>>;
 
     async fn create_pull_request(
         &self,
@@ -545,6 +551,26 @@ impl Session for GithubSession {
         return self
             .do_get_pull_requests(owner, repo, head, paging_url, err_fmt)
             .await;
+    }
+
+    async fn get_pull_request_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+    ) -> Result<Vec<PullRequestFile>> {
+        self.client
+            .get(&format!("repos/{}/{}/pulls/{}/files", owner, repo, number))
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "Error looking up files for PR: {}/{} #{}: {}",
+                    owner,
+                    repo,
+                    number,
+                    e
+                )
+            })
     }
 
     async fn create_pull_request(

--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -235,6 +235,12 @@ pub struct PullRequest {
     pub draft: Option<bool>,
 }
 
+// https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct PullRequestFile {
+    pub filename: String,
+}
+
 impl PullRequest {
     pub fn new() -> PullRequest {
         PullRequest {

--- a/octobot/tests/mocks/mock_github.rs
+++ b/octobot/tests/mocks/mock_github.rs
@@ -12,6 +12,7 @@ pub struct MockGithub {
     get_pr_calls: Mutex<Vec<MockCall<PullRequest>>>,
     get_prs_calls: Mutex<Vec<MockCall<Vec<PullRequest>>>>,
     get_prs_by_commit_calls: Mutex<Vec<MockCall<Vec<PullRequest>>>>,
+    get_pr_files_calls: Mutex<Vec<MockCall<Vec<PullRequestFile>>>>,
     create_pr_calls: Mutex<Vec<MockCall<PullRequest>>>,
     get_pr_labels_calls: Mutex<Vec<MockCall<Vec<Label>>>>,
     add_pr_labels_calls: Mutex<Vec<MockCall<()>>>,
@@ -61,6 +62,7 @@ impl MockGithub {
             get_pr_labels_calls: Mutex::new(vec![]),
             add_pr_labels_calls: Mutex::new(vec![]),
             get_pr_commits_calls: Mutex::new(vec![]),
+            get_pr_files_calls: Mutex::new(vec![]),
             get_pr_reviews_calls: Mutex::new(vec![]),
             assign_pr_calls: Mutex::new(vec![]),
             request_review_calls: Mutex::new(vec![]),
@@ -224,6 +226,21 @@ impl Session for MockGithub {
         assert_eq!(call.args[2], commit);
         assert_eq!(call.args[3], head.unwrap_or(""));
 
+        call.ret
+    }
+
+    async fn get_pull_request_files(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+    ) -> Result<Vec<PullRequestFile>> {
+        let mut calls = self.get_pr_files_calls.lock().unwrap();
+        assert!(calls.len() > 0, "Unexpected call to get_pull_request_files");
+        let call = calls.remove(0);
+        assert_eq!(call.args[0], owner);
+        assert_eq!(call.args[1], repo);
+        assert_eq!(call.args[2], number.to_string());
         call.ret
     }
 


### PR DESCRIPTION
This isn't used in octobot, this would enable things using octobot's
github API to list changed files from a PR.
