### PR TITLE
Don't fail backport on assign/review errors

### DIFF
--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -510,9 +510,8 @@ async fn test_pr_merge_conventional_commit() {
 }
 
 // Repeated failures from `assign_pull_request` must not be reported as a
-// failed backport: the backport PR already exists, so a "failed-backport"
-// comment/label on the original PR would be misleading. (MockGithub panics
-// on unexpected comment/label calls, which is what enforces this.)
+// failed backport: the backport PR already exists. Instead, a single
+// comment on the backport PR lists what needs to be done manually.
 #[tokio::test]
 async fn test_pr_merge_assign_failure_does_not_fail_backport() {
     let (test, _temp_dir) = new_test();
@@ -559,6 +558,14 @@ async fn test_pr_merge_assign_failure_does_not_fail_backport() {
             Err(anyhow!("nope")),
         );
     }
+
+    test.github.mock_comment_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        "Backport bot could not complete the following on this PR; please do them manually:\n\n- Assign @user1, @the-pr-author: `nope`",
+        Ok(()),
+    );
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
@@ -626,6 +633,94 @@ async fn test_pr_merge_request_review_failure_does_not_fail_backport() {
             Err(anyhow!("nope")),
         );
     }
+
+    test.github.mock_comment_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        "Backport bot could not complete the following on this PR; please do them manually:\n\n- Request review from @reviewer1: `nope`",
+        Ok(()),
+    );
+
+    let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
+    let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
+    pr_merge::merge_pull_request(
+        &test.git.git,
+        &test.github,
+        &req,
+        test.config,
+        test.slack.new_sender(),
+    )
+    .await;
+}
+
+// When both assign and request_review fail, both failures should be
+// consolidated into a single comment on the backport PR.
+#[tokio::test]
+async fn test_pr_merge_assign_and_review_failures_combined_in_one_comment() {
+    let (test, _temp_dir) = new_test();
+
+    test.git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    test.git.run_git(&["checkout", "master"]);
+    test.git
+        .add_repo_file("file.txt", "contents1", "I made a change");
+    let commit1 = test.git.git.current_commit().unwrap();
+
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.title = "The Title".into();
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+    pr.assignees = vec![github::User::new("user1")];
+    pr.requested_reviewers = Some(vec![github::User::new("reviewer1")]);
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    test.github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    for _ in 0..2 {
+        test.github.mock_assign_pull_request(
+            "the-owner",
+            "the-repo",
+            456,
+            vec!["user1".into(), "the-pr-author".into()],
+            Err(anyhow!("assign-broke")),
+        );
+    }
+    for _ in 0..2 {
+        test.github.mock_request_review(
+            "the-owner",
+            "the-repo",
+            456,
+            vec!["reviewer1".into()],
+            Err(anyhow!("review-broke")),
+        );
+    }
+
+    test.github.mock_comment_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        "Backport bot could not complete the following on this PR; please do them manually:\n\n\
+         - Assign @user1, @the-pr-author: `assign-broke`\n\
+         - Request review from @reviewer1: `review-broke`",
+        Ok(()),
+    );
 
     let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
     let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -509,6 +509,200 @@ async fn test_pr_merge_conventional_commit() {
     );
 }
 
+// Repeated failures from `assign_pull_request` must not be reported as a
+// failed backport: the backport PR already exists, so a "failed-backport"
+// comment/label on the original PR would be misleading. (MockGithub panics
+// on unexpected comment/label calls, which is what enforces this.)
+#[tokio::test]
+async fn test_pr_merge_assign_failure_does_not_fail_backport() {
+    let (test, _temp_dir) = new_test();
+
+    test.git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    test.git.run_git(&["checkout", "master"]);
+    test.git
+        .add_repo_file("file.txt", "contents1", "I made a change");
+    let commit1 = test.git.git.current_commit().unwrap();
+
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.title = "The Title".into();
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+    pr.assignees = vec![github::User::new("user1")];
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    test.github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    // Both attempts (initial + retry) return errors.
+    for _ in 0..2 {
+        test.github.mock_assign_pull_request(
+            "the-owner",
+            "the-repo",
+            456,
+            vec!["user1".into(), "the-pr-author".into()],
+            Err(anyhow!("nope")),
+        );
+    }
+
+    let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
+    let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
+    pr_merge::merge_pull_request(
+        &test.git.git,
+        &test.github,
+        &req,
+        test.config,
+        test.slack.new_sender(),
+    )
+    .await;
+}
+
+// Same as above but for `request_review`.
+#[tokio::test]
+async fn test_pr_merge_request_review_failure_does_not_fail_backport() {
+    let (test, _temp_dir) = new_test();
+
+    test.git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    test.git.run_git(&["checkout", "master"]);
+    test.git
+        .add_repo_file("file.txt", "contents1", "I made a change");
+    let commit1 = test.git.git.current_commit().unwrap();
+
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.title = "The Title".into();
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+    pr.requested_reviewers = Some(vec![github::User::new("reviewer1")]);
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    test.github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    test.github.mock_assign_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["the-pr-author".into()],
+        Ok(()),
+    );
+
+    for _ in 0..2 {
+        test.github.mock_request_review(
+            "the-owner",
+            "the-repo",
+            456,
+            vec!["reviewer1".into()],
+            Err(anyhow!("nope")),
+        );
+    }
+
+    let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
+    let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
+    pr_merge::merge_pull_request(
+        &test.git.git,
+        &test.github,
+        &req,
+        test.config,
+        test.slack.new_sender(),
+    )
+    .await;
+}
+
+// Verify the retry is single-shot, not infinite, and that a transient
+// failure on the first attempt is recovered when the second succeeds.
+#[tokio::test]
+async fn test_pr_merge_assign_succeeds_on_retry() {
+    let (test, _temp_dir) = new_test();
+
+    test.git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    test.git.run_git(&["checkout", "master"]);
+    test.git
+        .add_repo_file("file.txt", "contents1", "I made a change");
+    let commit1 = test.git.git.current_commit().unwrap();
+
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+    pr.assignees = vec![github::User::new("user1")];
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    test.github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    test.github.mock_assign_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["user1".into(), "the-pr-author".into()],
+        Err(anyhow!("transient")),
+    );
+    test.github.mock_assign_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["user1".into(), "the-pr-author".into()],
+        Ok(()),
+    );
+
+    let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
+    let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
+    pr_merge::merge_pull_request(
+        &test.git.git,
+        &test.github,
+        &req,
+        test.config,
+        test.slack.new_sender(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn test_pr_merge_backport_failure() {
     let (mut test, _temp_dir) = new_test();

--- a/ops/src/pr_merge.rs
+++ b/ops/src/pr_merge.rs
@@ -201,7 +201,17 @@ pub async fn try_merge_pull_request(
 
     // Errors past this point must not fail the backport: the backport PR has
     // already been created, so returning Err here would cause a misleading
-    // "failed backport" comment to be posted on the original PR.
+    // "failed backport" comment to be posted on the original PR. Instead,
+    // collect what failed and post a single comment on the backport PR so
+    // the owner knows to finish those steps by hand.
+    let mut manual_steps: Vec<String> = Vec::new();
+
+    let mut reviewers: Vec<String> = pull_request
+        .all_reviewers()
+        .into_iter()
+        .map(|a| a.login().to_string())
+        .collect();
+    reviewers.retain(|r| r != pull_request.user.login());
 
     if !assignees.is_empty() {
         let res = retry_once("assign_pull_request", || {
@@ -210,15 +220,18 @@ pub async fn try_merge_pull_request(
         .await;
         if let Err(e) = res {
             error!("Error assigning backport PR #{}: {}", new_pr.number, e);
+            manual_steps.push(format!(
+                "Assign {}: `{}`",
+                assignees
+                    .iter()
+                    .map(|a| format!("@{}", a))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                e
+            ));
         }
     }
 
-    let mut reviewers: Vec<String> = pull_request
-        .all_reviewers()
-        .into_iter()
-        .map(|a| a.login().to_string())
-        .collect();
-    reviewers.retain(|r| r != pull_request.user.login());
     if !reviewers.is_empty() {
         let res = retry_once("request_review", || {
             session.request_review(owner, repo, new_pr.number, reviewers.clone())
@@ -227,6 +240,31 @@ pub async fn try_merge_pull_request(
         if let Err(e) = res {
             error!(
                 "Error requesting reviewers on backport PR #{}: {}",
+                new_pr.number, e
+            );
+            manual_steps.push(format!(
+                "Request review from {}: `{}`",
+                reviewers
+                    .iter()
+                    .map(|r| format!("@{}", r))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                e
+            ));
+        }
+    }
+
+    if !manual_steps.is_empty() {
+        let msg = format!(
+            "Backport bot could not complete the following on this PR; please do them manually:\n\n- {}",
+            manual_steps.join("\n- ")
+        );
+        if let Err(e) = session
+            .comment_pull_request(owner, repo, new_pr.number, &msg)
+            .await
+        {
+            error!(
+                "Error commenting manual-steps notice on backport PR #{}: {}",
                 new_pr.number, e
             );
         }

--- a/ops/src/pr_merge.rs
+++ b/ops/src/pr_merge.rs
@@ -199,10 +199,18 @@ pub async fn try_merge_pull_request(
         assignees.push(pull_request.user.login().to_string());
     }
 
+    // Errors past this point must not fail the backport: the backport PR has
+    // already been created, so returning Err here would cause a misleading
+    // "failed backport" comment to be posted on the original PR.
+
     if !assignees.is_empty() {
-        session
-            .assign_pull_request(owner, repo, new_pr.number, assignees)
-            .await?;
+        let res = retry_once("assign_pull_request", || {
+            session.assign_pull_request(owner, repo, new_pr.number, assignees.clone())
+        })
+        .await;
+        if let Err(e) = res {
+            error!("Error assigning backport PR #{}: {}", new_pr.number, e);
+        }
     }
 
     let mut reviewers: Vec<String> = pull_request
@@ -212,9 +220,16 @@ pub async fn try_merge_pull_request(
         .collect();
     reviewers.retain(|r| r != pull_request.user.login());
     if !reviewers.is_empty() {
-        session
-            .request_review(owner, repo, new_pr.number, reviewers)
-            .await?;
+        let res = retry_once("request_review", || {
+            session.request_review(owner, repo, new_pr.number, reviewers.clone())
+        })
+        .await;
+        if let Err(e) = res {
+            error!(
+                "Error requesting reviewers on backport PR #{}: {}",
+                new_pr.number, e
+            );
+        }
     }
 
     if !whitespace_mode.is_empty() {
@@ -364,6 +379,21 @@ fn make_merge_desc(
     (title, body)
 }
 
+async fn retry_once<F, Fut, T>(label: &str, mut f: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    match f().await {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            info!("retrying {label} after 1s due to error: {e}");
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            f().await
+        }
+    }
+}
+
 async fn create_pr_with_retry(
     session: &dyn Session,
     owner: &str,
@@ -373,16 +403,10 @@ async fn create_pr_with_retry(
     pr_branch_name: &str,
     target_branch: &str,
 ) -> Result<github::PullRequest> {
-    let make_pr =
-        || session.create_pull_request(owner, repo, title, body, pr_branch_name, target_branch);
-    match make_pr().await {
-        Ok(pr) => Ok(pr),
-        Err(e) => {
-            info!("retrying create_pull_request after 1s due to error: {e}",);
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            make_pr().await
-        }
-    }
+    retry_once("create_pull_request", || {
+        session.create_pull_request(owner, repo, title, body, pr_branch_name, target_branch)
+    })
+    .await
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
The backport PR has already been created; bubbling up errors from assign_pull_request / request_review caused a misleading "failed-backport" comment and label on the original PR. Log and continue instead, with a single-shot retry to absorb transient 5xx.