### PR TITLE
Don't add bot reviewers to backports.

### DIFF
--- a/lib/src/github/models.rs
+++ b/lib/src/github/models.rs
@@ -113,6 +113,8 @@ pub struct User {
     pub id: u32,
     pub login: Option<String>,
     pub name: Option<String>,
+    #[serde(rename = "type", default)]
+    pub user_type: Option<String>,
 }
 
 impl User {
@@ -121,6 +123,7 @@ impl User {
             id: 0,
             login: Some(login.to_string()),
             name: Some(login.to_string()),
+            user_type: None,
         }
     }
 
@@ -129,6 +132,10 @@ impl User {
             .as_deref()
             .or(self.name.as_deref())
             .unwrap_or_default()
+    }
+
+    pub fn is_bot(&self) -> bool {
+        self.user_type.as_deref() == Some("Bot")
     }
 }
 

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -151,6 +151,76 @@ async fn test_pr_merge_basic() {
 }
 
 #[tokio::test]
+async fn test_pr_merge_skips_bot_reviewers() {
+    let (test, _temp_dir) = new_test();
+
+    // setup a release branch
+    test.git.run_git(&["push", "origin", "master:release/1.0"]);
+
+    // make a new commit on master
+    test.git.run_git(&["checkout", "master"]);
+    test.git
+        .add_repo_file("file.txt", "contents1", "I made a change");
+    let commit1 = test.git.git.current_commit().unwrap();
+
+    // pretend this came from a PR
+    let mut pr = github::PullRequest::new();
+    pr.number = 123;
+    pr.merged = Some(true);
+    pr.merge_commit_sha = Some(commit1.clone());
+    pr.head = github::BranchRef::new("my-feature-branch");
+    pr.base = github::BranchRef::new("master");
+
+    let mut bot_reviewer = github::User::new("some-bot[bot]");
+    bot_reviewer.user_type = Some("Bot".into());
+    pr.requested_reviewers = Some(vec![github::User::new("reviewer1"), bot_reviewer]);
+    pr.user = github::User::new("the-pr-author");
+    let pr = pr;
+
+    let mut new_pr = github::PullRequest::new();
+    new_pr.number = 456;
+    let new_pr = new_pr;
+
+    test.github.mock_create_pull_request(
+        "the-owner",
+        "the-repo",
+        "master->1.0: I made a change",
+        &format!("(cherry-picked from {}, PR #123)", commit1),
+        "my-feature-branch-1.0",
+        "release/1.0",
+        Ok(new_pr),
+    );
+
+    test.github.mock_assign_pull_request(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["the-pr-author".into()],
+        Ok(()),
+    );
+
+    // the bot reviewer must be filtered out, leaving only reviewer1
+    test.github.mock_request_review(
+        "the-owner",
+        "the-repo",
+        456,
+        vec!["reviewer1".into()],
+        Ok(()),
+    );
+
+    let repo = github::Repo::parse("http://the-github-host/the-owner/the-repo").unwrap();
+    let req = pr_merge::req(&repo, &pr, "release/1.0", "release/", &[]);
+    pr_merge::merge_pull_request(
+        &test.git.git,
+        &test.github,
+        &req,
+        test.config,
+        test.slack.new_sender(),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_pr_merge_author_is_assignee() {
     let (test, _temp_dir) = new_test();
 

--- a/octobot/tests/pr_merge_test.rs
+++ b/octobot/tests/pr_merge_test.rs
@@ -151,7 +151,7 @@ async fn test_pr_merge_basic() {
 }
 
 #[tokio::test]
-async fn test_pr_merge_skips_bot_reviewers() {
+async fn test_pr_merge_skips_bots() {
     let (test, _temp_dir) = new_test();
 
     // setup a release branch
@@ -171,10 +171,17 @@ async fn test_pr_merge_skips_bot_reviewers() {
     pr.head = github::BranchRef::new("my-feature-branch");
     pr.base = github::BranchRef::new("master");
 
-    let mut bot_reviewer = github::User::new("some-bot[bot]");
+    let mut bot_reviewer = github::User::new("review-bot[bot]");
     bot_reviewer.user_type = Some("Bot".into());
     pr.requested_reviewers = Some(vec![github::User::new("reviewer1"), bot_reviewer]);
-    pr.user = github::User::new("the-pr-author");
+
+    let mut bot_assignee = github::User::new("assign-bot[bot]");
+    bot_assignee.user_type = Some("Bot".into());
+    pr.assignees = vec![github::User::new("user1"), bot_assignee];
+
+    let mut bot_author = github::User::new("author-bot[bot]");
+    bot_author.user_type = Some("Bot".into());
+    pr.user = bot_author;
     let pr = pr;
 
     let mut new_pr = github::PullRequest::new();
@@ -191,11 +198,12 @@ async fn test_pr_merge_skips_bot_reviewers() {
         Ok(new_pr),
     );
 
+    // bot assignee and bot author must both be filtered, leaving only user1
     test.github.mock_assign_pull_request(
         "the-owner",
         "the-repo",
         456,
-        vec!["the-pr-author".into()],
+        vec!["user1".into()],
         Ok(()),
     );
 

--- a/ops/src/pr_merge.rs
+++ b/ops/src/pr_merge.rs
@@ -186,6 +186,7 @@ pub async fn try_merge_pull_request(
     let mut assignees: Vec<String> = pull_request
         .assignees
         .iter()
+        .filter(|a| !a.is_bot())
         .map(|a| a.login().to_string())
         .collect();
 
@@ -194,6 +195,7 @@ pub async fn try_merge_pull_request(
     // in any way.  To raise the visibility, add the original PR author
     // to the list of assignees
     if !pull_request.user.login().is_empty()
+        && !pull_request.user.is_bot()
         && !assignees.contains(&pull_request.user.login().to_string())
     {
         assignees.push(pull_request.user.login().to_string());

--- a/ops/src/pr_merge.rs
+++ b/ops/src/pr_merge.rs
@@ -208,6 +208,7 @@ pub async fn try_merge_pull_request(
     let mut reviewers: Vec<String> = pull_request
         .all_reviewers()
         .into_iter()
+        .filter(|a| !a.is_bot())
         .map(|a| a.login().to_string())
         .collect();
     reviewers.retain(|r| r != pull_request.user.login());


### PR DESCRIPTION
Adding a bot reviewer like claude to a backport is meaningless,
and may fail if the bot does not have contributor status.
